### PR TITLE
Update disco switch schema to use standard column names

### DIFF
--- a/schema/switch.json
+++ b/schema/switch.json
@@ -2,6 +2,7 @@
     { "name": "test_id", "type": "STRING"},
     { "name": "task_filename", "type": "STRING"},
     { "name": "parse_time", "type": "TIMESTAMP"},
+    { "name": "parser_version", "type": "STRING"},
     { "name": "log_time", "type": "TIMESTAMP"},
     { "name": "sample", "type": "RECORD", "mode": "REPEATED", "fields": [
             { "name": "timestamp", "type": "TIMESTAMP" },

--- a/schema/switch.json
+++ b/schema/switch.json
@@ -1,10 +1,8 @@
 [
-    { "name": "meta", "type": "RECORD", "fields": [
-            { "name": "task_filename", "type": "STRING" },
-            { "name": "test_id", "type": "STRING" },
-            { "name": "parse_time", "type": "TIMESTAMP" }
-        ]
-    },
+    { "name": "task_filename", "type": "STRING" },
+    { "name": "test_id", "type": "STRING" },
+    { "name": "log_time", "type": "TIMESTAMP" },
+    { "name": "parse_time", "type": "TIMESTAMP" },
     { "name": "sample", "type": "RECORD", "mode": "REPEATED", "fields": [
             { "name": "timestamp", "type": "TIMESTAMP" },
             { "name": "value", "type": "FLOAT" }

--- a/schema/switch.json
+++ b/schema/switch.json
@@ -1,8 +1,8 @@
 [
-    { "name": "task_filename", "type": "STRING" },
-    { "name": "test_id", "type": "STRING" },
-    { "name": "log_time", "type": "TIMESTAMP" },
-    { "name": "parse_time", "type": "TIMESTAMP" },
+    { "name": "test_id", "type": "STRING"},
+    { "name": "task_filename", "type": "STRING"},
+    { "name": "parse_time", "type": "TIMESTAMP"},
+    { "name": "log_time", "type": "TIMESTAMP"},
     { "name": "sample", "type": "RECORD", "mode": "REPEATED", "fields": [
             { "name": "timestamp", "type": "TIMESTAMP" },
             { "name": "value", "type": "FLOAT" }


### PR DESCRIPTION
This change modifies the DISCO switch schema to use the standard column names shared with the other data sets.

This change is happening now in advance of documenting the switch table schema and officially supporting the DISCO switch dataset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/5)
<!-- Reviewable:end -->
