### PR TITLE
Add standard columns to all schemas

### DIFF
--- a/schema/ndt.json
+++ b/schema/ndt.json
@@ -2,6 +2,7 @@
       { "name": "test_id", "type": "STRING"},
       { "name": "task_filename", "type": "STRING"},
       { "name": "parse_time", "type": "TIMESTAMP"},
+      { "name": "parser_version", "type": "STRING"},
       { "name": "log_time", "type": "TIMESTAMP"},
       { "name": "blacklist_flags", "type": "INTEGER", "description": "Deprecated.  Use flag in anomalies record instead."},
       {

--- a/schema/ndt_delta.json
+++ b/schema/ndt_delta.json
@@ -2,6 +2,7 @@
       { "name": "test_id", "type": "STRING"},
       { "name": "task_filename", "type": "STRING"},
       { "name": "parse_time", "type": "TIMESTAMP"},
+      { "name": "parser_version", "type": "STRING"},
       { "name": "log_time", "type": "TIMESTAMP"},
       { "name": "blacklist_flags", "type": "INTEGER", "description": "Deprecated.  Use flag in anomalies record instead."},
       {

--- a/schema/pt.json
+++ b/schema/pt.json
@@ -1,5 +1,8 @@
 [
       { "name": "test_id", "type": "STRING"},
+      { "name": "task_filename", "type": "STRING"},
+      { "name": "parse_time", "type": "TIMESTAMP"},
+      { "name": "parser_version", "type": "STRING"},
       { "name": "project", "type": "INTEGER"},
       { "name": "log_time", "type": "TIMESTAMP"},
       { "name": "type", "type": "INTEGER"},


### PR DESCRIPTION
This PR adds missing column names to the four data sets. https://github.com/m-lab/etl/issues/285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/7)
<!-- Reviewable:end -->
