### PR TITLE
Add --headless parameter to bq during auth init

### DIFF
--- a/schema/sync_tables_with_schema.sh
+++ b/schema/sync_tables_with_schema.sh
@@ -35,7 +35,7 @@ trap "cleanup" INT TERM EXIT
 # generates an unconditional "Welcome to BigQuery!" preamble message, which
 # corrupts the remaining json output. The following command attempts to list a
 # fake dataset which runs through the auth initialization and welcome message.
-bq --project ${PROJECT} ls fake-dataset &> /dev/null || :
+bq --headless --project ${PROJECT} ls fake-dataset &> /dev/null || :
 
 for schema_file in `ls "${BASEDIR}"/*.json`; do
     table="$( basename ${schema_file%%.json} )"


### PR DESCRIPTION
Evidently, bq is able to use service account credentials to get a list of all BQ projects that it may want to use (despite the given --project parameter) and prompts the users to choose a default. This causes some deployments to hang when the service account has permission to write to multiple projects, e.g. mlab-oti & measurement-lab. With the headless parameter `bq` simply skips that step and uses the given project name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/11)
<!-- Reviewable:end -->
