### PR TITLE
Update release views to reference canonical experiment data type views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # etl-schema
+
 | branch | travis-ci | report-card | coveralls |
 |--------|-----------|-----------|-------------|
 | master | [![Travis Build Status](https://travis-ci.org/m-lab/etl-schema.svg?branch=master)](https://travis-ci.org/m-lab/etl-schema) | | [![Coverage Status](https://coveralls.io/repos/m-lab/etl-schema/badge.svg?branch=master)](https://coveralls.io/github/m-lab/etl-schema?branch=master) |
 
-[![Waffle.io](https://badge.waffle.io/m-lab/etl-schema.svg?title=Ready)](http://waffle.io/m-lab/etl-schema)
+Schema definitions for the MeasurementLab data ingestion pipeline.
 
-MeasurementLab data ingestion pipeline.
+## To create the private dataset
 
-### To create e.g., NDT table (should rarely be required!!!):
-```bash
-bq mk --time_partitioning_type=DAY --schema=schema/ndt_delta.json mlab-sandbox:batch.ndt
-```
-
-### To create the private dataset:
 ```bash
 bq mk mlab-oti:private
 bq update --source acl/private.acl.json mlab-oti:private
 ```
 
-### To create the private production NDT table (should rarely be required!!!):
+## To create the private table (should rarely be required!!!)
+
 ```bash
-bq mk --time_partitioning_type=DAY --schema=schema/ss.json mlab-oti:private.sidestream
+bq mk --time_partitioning_type=DAY --schema=schema/ss.json \
+   mlab-oti:private.sidestream
 ```
 
-### To update a table's schema in place:
+## To update a table's schema in place
+
+NOTE: schema updates are best used to add new columns. See [modiying table
+schemas](https://cloud.google.com/bigquery/docs/managing-table-schemas) for
+other use cases.
+
 ```bash
 bq update mlab-sandbox:private.sidestream schema/ss.json
 ```
 
-## Also see schema/README.md.
+## Also see schema/README.md
 
+[schema/README.md](schema/README.md)

--- a/README.md
+++ b/README.md
@@ -6,30 +6,6 @@
 
 Schema definitions for the MeasurementLab data ingestion pipeline.
 
-## To create the private dataset
-
-```bash
-bq mk mlab-oti:private
-bq update --source acl/private.acl.json mlab-oti:private
-```
-
-## To create the private table (should rarely be required!!!)
-
-```bash
-bq mk --time_partitioning_type=DAY --schema=schema/ss.json \
-   mlab-oti:private.sidestream
-```
-
-## To update a table's schema in place
-
-NOTE: schema updates are best used to add new columns. See [modiying table
-schemas](https://cloud.google.com/bigquery/docs/managing-table-schemas) for
-other use cases.
-
-```bash
-bq update mlab-sandbox:private.sidestream schema/ss.json
-```
-
 ## Also see schema/README.md
 
 [schema/README.md](schema/README.md)

--- a/schema/README.md
+++ b/schema/README.md
@@ -43,3 +43,15 @@ switch.json contains the schema for DISCO tables. To create a new table:
 
     bq --project_id mlab-sandbox mk --time_partitioning_type=DAY \
         --schema schema/switch.json -t base_tables.switch
+
+## Update Table Schema in Place
+
+NOTE: schema updates are best used to add new columns. See [modiying table
+schemas](https://cloud.google.com/bigquery/docs/managing-table-schemas) for
+other use cases.
+
+For example:
+
+```bash
+bq update mlab-sandbox:private.sidestream schema/ss.json
+```

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,3 +1,5 @@
+# Schema
+
 Schema includes bigquery schema (json) files, and code associated with
 populating bigquery entities.
 

--- a/schema/views_standardsql/common_etl.sql
+++ b/schema/views_standardsql/common_etl.sql
@@ -80,5 +80,5 @@ SELECT
     AS snap)
     */
   AS web100_log_entry
-FROM `${PROJECT}.base_tables.ndt`
+FROM `${PROJECT}.ndt.web100`
 -- WHERE _PARTITIONTIME >= TIMESTAMP("2017-05-11 00:00:00")

--- a/schema/views_standardsql/common_etl.sql
+++ b/schema/views_standardsql/common_etl.sql
@@ -2,7 +2,7 @@
 -- ETL table projected into common schema, for union with PLX legacy data.
 SELECT
   test_id,
-  DATE(_PARTITIONTIME) AS partition_date,
+  partition_date,
   0 AS project, -- not included in ETL
   log_time,
   task_filename,


### PR DESCRIPTION
This change updates `common_etl.sql` to query the canonical experiment data type views in measurement-lab.

This change also includes minor lint clean ups for the README.md files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/25)
<!-- Reviewable:end -->
