### PR TITLE
Add 'dataset creation' with complete AccessEntry to bq-create-view

### DIFF
--- a/cmd/bq_create_view/main.go
+++ b/cmd/bq_create_view/main.go
@@ -137,7 +137,7 @@ func syncDataset(ctx context.Context, ds datasetInterface, user string) error {
 	}
 
 	// If user is already present in the access entry list, then we're done.
-	if userCanAccess(user, md.Access) {
+	if user == "" || userCanAccess(user, md.Access) {
 		return nil
 	}
 

--- a/cmd/bq_create_view/main.go
+++ b/cmd/bq_create_view/main.go
@@ -19,6 +19,7 @@ var (
 	viewSource   = flag.String("create-view", "", "Source view id: <project>.<dataset>.<view>")
 	accessTarget = flag.String("to-access", "", "Target table id accessed by view. Must already exist.")
 	description  = flag.String("description", "", "Description for view")
+	user         = flag.String("user", "", "When creating the view dataset, add edit access for user.")
 	logLevel     = flag.Int("log.level", 4, "Log level")
 )
 
@@ -45,6 +46,17 @@ func canAccess(table *bigquery.Table, access []*bigquery.AccessEntry) bool {
 	for i := range access {
 		if access[i].View != nil {
 			if equalTables(access[i].View, table) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func userCanAccess(user string, access []*bigquery.AccessEntry) bool {
+	for i := range access {
+		if access[i].EntityType == bigquery.UserEmailEntity {
+			if access[i].Entity == user {
 				return true
 			}
 		}
@@ -92,6 +104,48 @@ func syncView(ctx context.Context, tb tableInterface, view *bigquery.Table, sql,
 type datasetInterface interface {
 	Metadata(ctx context.Context) (*bigquery.DatasetMetadata, error)
 	Update(ctx context.Context, tm bigquery.DatasetMetadataToUpdate, etag string) (*bigquery.DatasetMetadata, error)
+	Create(ctx context.Context, tm *bigquery.DatasetMetadata) error
+}
+
+func syncDataset(ctx context.Context, ds datasetInterface, user string) error {
+	md, err := ds.Metadata(ctx)
+	if err != nil {
+		apiErr, ok := err.(*googleapi.Error)
+		if !ok {
+			// This is not a googleapi.Error, so treat it as fatal.
+			return err
+		}
+		// We can only handle 404 errors caused by the view not existing.
+		if apiErr.Code != 404 {
+			return err
+		}
+		if user == "" {
+			return fmt.Errorf("User must not be empty")
+		}
+		log.Info("Creating dataset")
+		err = ds.Create(ctx, &bigquery.DatasetMetadata{
+			Access: []*bigquery.AccessEntry{
+				// Default access entries.
+				{Role: bigquery.OwnerRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectOwners"},
+				{Role: bigquery.WriterRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectWriters"},
+				{Role: bigquery.ReaderRole, EntityType: bigquery.SpecialGroupEntity, Entity: "projectReaders"},
+				// Access entry for service accounts or individual users beyond the default.
+				{Role: bigquery.WriterRole, EntityType: bigquery.UserEmailEntity, Entity: user},
+			},
+		})
+		return err
+	}
+
+	// If user is already present in the access entry list, then we're done.
+	if userCanAccess(user, md.Access) {
+		return nil
+	}
+
+	// Add user. Note: if a service account is not already present, it may not have permission to add itself.
+	acl := append(md.Access, &bigquery.AccessEntry{
+		Role: bigquery.WriterRole, EntityType: bigquery.UserEmailEntity, Entity: user})
+	_, err = ds.Update(ctx, bigquery.DatasetMetadataToUpdate{Access: acl}, md.ETag)
+	return err
 }
 
 func syncDatasetAccess(ctx context.Context, ds datasetInterface, view, target *bigquery.Table) error {
@@ -160,9 +214,15 @@ func main() {
 	viewClient, err := bigquery.NewClient(ctx, view.ProjectID)
 	rtx.Must(err, "Failed to create bigquery.Client")
 
+	// Create or Update view dataset.
+	log.Info("Syncing view dataset: ", id(view))
+	viewDs := viewClient.Dataset(view.DatasetID)
+	err = syncDataset(ctx, viewDs, *user)
+	rtx.Must(err, "Failed to sync dataset: %q", viewDs.DatasetID)
+
 	// Create or Update view query and description.
 	log.Info("Reading view metadata: ", id(view))
-	tb := viewClient.Dataset(view.DatasetID).Table(view.TableID)
+	tb := viewDs.Table(view.TableID)
 	err = syncView(ctx, tb, view, sql, *description)
 	rtx.Must(err, "Failed to sync view %q", id(view))
 

--- a/schema/views_standardsql/create_named_views.sh
+++ b/schema/views_standardsql/create_named_views.sh
@@ -23,15 +23,14 @@ _=${1:?Please provide set of view assignments: $USAGE}
 
 echo "${!KEYNAME}" > /tmp/sa.json
 export GOOGLE_APPLICATION_CREDENTIALS=/tmp/sa.json
+# Extract service account user name.
+USER=$( gcloud config get-value account )
 
 for assignment in $@ ; do
 
   # Extract the source table and destination view from the assignment spec.
   src=${assignment%%=*}
   dest=${assignment##*=}
-
-  # Make dataset for view.
-  bq mk "${DST_PROJECT}:${dest%%.*}" || :
 
   # Make view referring to the source table.
   description="Release tag: $TRAVIS_TAG     Commit: $TRAVIS_COMMIT"$'\n'
@@ -41,5 +40,6 @@ for assignment in $@ ; do
   bq_create_view \
       -create-view "${DST_PROJECT}.${dest}" \
       -description "${description}" \
-      -to-access "${SRC_PROJECT}.${src}"
+      -to-access "${SRC_PROJECT}.${src}" \
+      -user "${USER}"
 done


### PR DESCRIPTION
This change fixes https://github.com/m-lab/etl-schema/issues/26

This change should guarantee that bq-create-view adds the service account user to the dataset access entry on creation. While using `bq mk` was previously sufficient using a service account with appropriate permissions, updating the access entries explicitly appears to be necessary now.

This issue interrupted the recent etl-schema production tag (resolved manually) - https://travis-ci.org/m-lab/etl-schema/builds/518509483

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/27)
<!-- Reviewable:end -->
