### PR TITLE
Change ASN to integer, add top level fields

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -13,14 +13,8 @@ All parsers write to the `base_tables` dataset.
 ndt.json contains the schema for the NDT tables. It can be used to
 create a new table in mlab-sandbox project by invoking:
 
-    bq --project_id mlab-sandbox mk --time_partitioning_type=DAY \
-        --schema schema/ndt.json -t base_tables.ndt
-
-ndt_delta.json contains another NDT schema, including a repeated "delta" field,
-intended to contain snapshot deltas. To create a new table:
-
-    bq --project_id mlab-sandbox mk --time_partitioning_type=DAY \
-        --schema schema/ndt_delta.json -t base_tables.ndt_delta
+    bq --project_id mlab-sandbox mk --time_partitioning_field=log_time \
+        --schema schema/ndt.json --clustering_fields client_country,client_asn,client_region,server_asn -t ndt.web100
 
 ## Paris-Traceroute
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -13,8 +13,9 @@ All parsers write to the `base_tables` dataset.
 ndt.json contains the schema for the NDT tables. It can be used to
 create a new table in mlab-sandbox project by invoking:
 
-    bq --project_id mlab-sandbox mk --time_partitioning_field=log_time \
-        --schema schema/ndt.json --clustering_fields client_country,client_asn,client_region,server_asn -t ndt.web100
+    bq mk --time_partitioning_field=log_time \
+    --clustering_fields client_country,client_asn,client_region,server_asn \
+    -t mlab-sandbox:ndt.web100 schema/ndt.json
 
 ## Paris-Traceroute
 

--- a/schema/ndt.json
+++ b/schema/ndt.json
@@ -5,6 +5,11 @@
       { "name": "parser_version", "type": "STRING"},
       { "name": "log_time", "type": "TIMESTAMP"},
       { "name": "blacklist_flags", "type": "INTEGER", "description": "Deprecated.  Use flag in anomalies record instead."},
+      { "name": "server_city", "type": "STRING", "description": "Server City - clustered"},
+      { "name": "server_asn", "type": "INTEGER", "description": "Server ASN - clustered"},
+      { "name": "client_country", "type": "STRING", "description": "Client country - clustered"},
+      { "name": "client_region", "type": "STRING", "description": "Client subdivision_1_name - clustered"},
+      { "name": "client_asn", "type": "INTEGER", "description": "Client ASN - clustered"},
       {
         "fields": [
           { "name": "no_meta", "type": "BOOLEAN"},

--- a/schema/ndt.json
+++ b/schema/ndt.json
@@ -33,7 +33,7 @@
             "fields": [
             {
               "fields": [
-                { "name": "asn", "type": "STRING", "description": "Autonomous System Number"}
+                { "name": "asn", "type": "INTEGER", "description": "Autonomous System Number"}
               ], "name": "network", "type": "RECORD"}
             ], "name": "client", "type": "RECORD", "description" : "client meta-data and annotations"},
           {
@@ -41,7 +41,7 @@
               { "name": "iata_code", "type": "STRING", "description": "IATA airport code (of server)"},
               {
               "fields": [
-                { "name": "asn", "type": "STRING", "description": "Autonomous System Number"}
+                { "name": "asn", "type": "INTEGER", "description": "Autonomous System Number"}
               ], "name": "network", "type": "RECORD"}
             ], "name": "server", "type": "RECORD", "description" : "server meta-data and annotations"},
           {

--- a/schema/sync_table.sh
+++ b/schema/sync_table.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# sync_TABLE.sh creates or updates a single BQ TABLEs using local schema
+# definitions. If the remote schema for an existing TABLE is structurally
+# different than the local schema, the difference is printed before being
+# updated.
+#
+# By default, sync_TABLE.sh run in dryrun mode, making no
+# permanent changes. To commit changes, provide the final argument 'nodryrun'.
+#
+# Example:
+#   ./sync_TABLE.sh mlab-sandbox:ndt.web100 ndt.json [nodryrun]
+
+
+USAGE="$0 <full-TABLE-name> <schema file>"
+FULL_TABLE=${1:?Please specify the full TABLE name, e.g. "mlab-sandbox:ndt.web100": $USAGE}
+SCHEMA_FILE=${2:?Please specify the full schema name, e.g. "ndt.json": $USAGE}
+NODRYRUN=${3:-dryrun} # Run in dryrun mode by default.
+
+set -eu
+
+[[ ${FULL_TABLE} =~ (.*):(.*)\.(.*) ]]    # BASH_REMATCH[0] is now "bcd"
+
+PROJECT=${BASH_REMATCH[1]}
+DATASET=${BASH_REMATCH[2]}
+TABLE=${BASH_REMATCH[3]}
+
+echo ${PROJECT} ${DATASET} ${TABLE}
+
+# Cleanup the temp directory before exiting for any reason.
+function cleanup() {
+    local rv=$?
+    rm -rf "${TEMPDIR}"
+    exit $rv
+}
+trap "cleanup" INT TERM EXIT
+
+TEMPDIR=$( mktemp -d )
+BASEDIR="$(dirname "$0")"
+
+# NOTE: the bq cli leverages the gcloud auth, however still must perform an
+# authentication initialization on the first run. This initialization also
+# generates an unconditional "Welcome to BigQuery!" preamble message, which
+# corrupts the remaining json output. The following command attempts to list a
+# fake dataset which runs through the auth initialization and welcome message.
+bq --headless --project ${PROJECT} ls fake-dataset &> /dev/null || :
+
+
+# Try to fetch current schema as JSON.
+if ! bq --project ${PROJECT} show --format=prettyjson \
+   --schema ${DATASET}.${TABLE} > ${TEMPDIR}/${TABLE}.json ; then
+
+    echo "Creating(${NODRYRUN}): ${PROJECT}:${DATASET}.${TABLE}"
+    set -x
+    if [[ "${NODRYRUN}" == "nodryrun" ]] ; then
+        bq --project_id ${PROJECT} mk \
+          --time_partitioning_field=log_time \
+          --clustering_fields=client_country,client_asn \
+          --schema ${SCHEMA_FILE} -t "${DATASET}.${TABLE}"
+    fi
+
+    # We have just created the TABLE, so the schema is guaranteed to match.
+else
+
+    # Compare the normalized JSON schema files.
+    #
+    # NOTE: `diff` alone reports differences that don't matter. So, we use jq
+    # to perform a structural equal operation, irrespective of object order.
+    # NOTE: the jq query takes in the two files, assumes they're an array,
+    # sorts the objects in the array and compares the result.
+    jq_filter='($a|(.|arrays)|=sort) as $a|($b|(.|arrays)|=sort) as $b|$a==$b'
+    match=$( jq --argfile a "${TEMPDIR}/${TABLE}.json" \
+                --argfile b "${SCHEMA_FILE}" \
+                -n "${jq_filter}" )
+
+    if [[ "${match}" == "false" ]] ; then
+        echo "WARNING: remote and local schemas do not match:" >&2
+        echo "WARNING: (<) ${PROJECT}:${DATASET}.${TABLE}" >&2
+        echo "WARNING: (>) ${SCHEMA_FILE}" >&2
+        diff <( python -m json.tool "${TEMPDIR}/${TABLE}.json" ) \
+         <( python -m json.tool "${SCHEMA_FILE}" ) || :
+
+        echo "Updating(${NODRYRUN}): ${PROJECT}:${DATASET}.${TABLE}"
+        set -x
+        if [[ "${NODRYRUN}" == "nodryrun" ]] ; then
+            bq update "${FULL_TABLE}" ${SCHEMA_FILE}
+        fi
+
+    else
+
+        # Both match so nothing to do.
+        echo "Success(${NODRYRUN}): ${PROJECT}:${DATASET}.$TABLE matches ${TABLE}.json"
+    fi
+
+fi

--- a/schema/sync_table.sh
+++ b/schema/sync_table.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 #
-# sync_TABLE.sh creates or updates a single BQ TABLEs using local schema
+# sync_table.sh creates or updates a single BQ table using local schema
 # definitions. If the remote schema for an existing TABLE is structurally
 # different than the local schema, the difference is printed before being
 # updated.
 #
-# By default, sync_TABLE.sh run in dryrun mode, making no
+# By default, sync_table.sh run in dryrun mode, making no
 # permanent changes. To commit changes, provide the final argument 'nodryrun'.
 #
 # Example:
-#   ./sync_TABLE.sh mlab-sandbox:ndt.web100 ndt.json [nodryrun]
+#   ./sync_table.sh mlab-sandbox:ndt.web100 ndt.json [nodryrun]
 
 
 USAGE="$0 <full-TABLE-name> <schema file>"
@@ -19,7 +19,7 @@ NODRYRUN=${3:-dryrun} # Run in dryrun mode by default.
 
 set -eu
 
-[[ ${FULL_TABLE} =~ (.*):(.*)\.(.*) ]]    # BASH_REMATCH[0] is now "bcd"
+[[ ${FULL_TABLE} =~ (.*):(.*)\.(.*) ]]    # parse the project:dataset.table string
 
 PROJECT=${BASH_REMATCH[1]}
 DATASET=${BASH_REMATCH[2]}


### PR DESCRIPTION
This PR:
 1. Adds sync_table.sh to explicitly sync a single table.  Required for new naming scheme.
 1. changes asn fields to be integers, and adds top level fields for purpose of clustering.
 1. updates bq command in schema/README.md to include clustering options.

TODO: Additional changes in ETL pipeline code are required before actually creating the new tables.  The schema is not disruptive, but the change in partition type is.  Top level cluster columns will also need to be explicitly populated in code.  For NDT, this might be done in the fixValues function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/30)
<!-- Reviewable:end -->
