### PR TITLE
Adds a synthetic column for our most common query.

### DIFF
--- a/views/ndt/referenced-by/referenced-by/downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/downloads.sql
@@ -12,10 +12,12 @@ SELECT
       --
       -- TODO: Delete this once https://github.com/m-lab/etl/issues/663 is
       -- resolved.
-       8 * (web100_log_entry.snap.HCThruOctetsAcked /
-       (web100_log_entry.snap.SndLimTimeRwin +
-        web100_log_entry.snap.SndLimTimeCwnd +
-        web100_log_entry.snap.SndLimTimeSnd)) AS MeanDownloadThroughputMbps
+      STRUCT(
+        8 * (web100_log_entry.snap.HCThruOctetsAcked /
+        (web100_log_entry.snap.SndLimTimeRwin +
+         web100_log_entry.snap.SndLimTimeCwnd +
+         web100_log_entry.snap.SndLimTimeSnd)) AS mean_download_throughput_mbps
+      ) as alpha
 FROM `%s.ndt.recommended`
 WHERE
   -- download direction, and at least 8KB transfered

--- a/views/ndt/referenced-by/referenced-by/downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/downloads.sql
@@ -9,6 +9,9 @@ SELECT
       -- and as such is a fairer representation of how fast we were able to
       -- push data down the pipe than just dividing by
       -- web100_log_entry.snap.Duration
+      --
+      -- TODO: Delete this once https://github.com/m-lab/etl/issues/663 is
+      -- resolved.
        8 * (web100_log_entry.snap.HCThruOctetsAcked /
        (web100_log_entry.snap.SndLimTimeRwin +
         web100_log_entry.snap.SndLimTimeCwnd +

--- a/views/ndt/referenced-by/referenced-by/downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/downloads.sql
@@ -1,6 +1,15 @@
 #standardSQL
--- All good quality download tests
-SELECT * FROM `%s.ndt.recommended`
+SELECT
+       -- All good quality download tests
+       *,
+       -- A synthetic column that conforms to our best practices.
+       -- The times are in microseconds, and dividing total throughput by total microseconds yields
+       -- mean throughput in Megabits per second.
+       8 * (web100_log_entry.snap.HCThruOctetsAcked /
+       (web100_log_entry.snap.SndLimTimeRwin +
+        web100_log_entry.snap.SndLimTimeCwnd +
+        web100_log_entry.snap.SndLimTimeSnd)) AS MeanDownloadThroughputMbps
+FROM `%s.ndt.recommended`
 WHERE
   -- download direction, and at least 8KB transfered
   connection_spec.data_direction IS NOT NULL

--- a/views/ndt/referenced-by/referenced-by/downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/downloads.sql
@@ -7,7 +7,7 @@ SELECT
       -- microseconds yields mean throughput in Megabits per second.  This
       -- query excludes any time during which the connection was quiescent,
       -- and as such is a fairer representation of how fast we were able to
-      -- push data down the pipe than just dividing by
+      -- push data down the pipe as compared to just dividing by
       -- web100_log_entry.snap.Duration
       --
       -- TODO: Delete this once https://github.com/m-lab/etl/issues/663 is

--- a/views/ndt/referenced-by/referenced-by/downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/downloads.sql
@@ -1,10 +1,14 @@
 #standardSQL
 SELECT
-       -- All good quality download tests
+      -- All good quality download tests
        *,
-       -- A synthetic column that conforms to our best practices.
-       -- The times are in microseconds, and dividing total throughput by total microseconds yields
-       -- mean throughput in Megabits per second.
+      -- A synthetic column that conforms to our best practices.
+      -- The times are in microseconds, and dividing total throughput by total
+      -- microseconds yields mean throughput in Megabits per second.  This
+      -- query excludes any time during which the connection was quiescent,
+      -- and as such is a fairer representation of how fast we were able to
+      -- push data down the pipe than just dividing by
+      -- web100_log_entry.snap.Duration
        8 * (web100_log_entry.snap.HCThruOctetsAcked /
        (web100_log_entry.snap.SndLimTimeRwin +
         web100_log_entry.snap.SndLimTimeCwnd +


### PR DESCRIPTION
Currently how things are set up in sandbox.

https://bigquery.cloud.google.com/table/mlab-sandbox:ndt.downloads

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/37)
<!-- Reviewable:end -->
