### PR TITLE
Use Go text/template syntax

### DIFF
--- a/cmd/bq_create_view/main.go
+++ b/cmd/bq_create_view/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
+	"text/template"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -216,7 +218,12 @@ func main() {
 	// Parsing flags.
 	view := parseTableID(*viewSource)
 	target := parseTableID(*accessTarget)
-	sql := fmt.Sprintf(viewTemplate.String(), target.ProjectID)
+
+	// Evaluate viewTemplate.
+	var viewContent bytes.Buffer
+	tmpl := template.Must(template.New("template").Parse(viewTemplate.String()))
+	rtx.Must(tmpl.Execute(&viewContent, target), "Failed to execute view template: %q", viewTemplate)
+	sql := viewContent.String()
 
 	// Create a context that expires after 1 min.
 	ctx, cancelCtx := context.WithTimeout(context.Background(), time.Minute)

--- a/views/README.md
+++ b/views/README.md
@@ -29,8 +29,9 @@ This will result in creation, e.g. for mlab-sandbox, of:
 - mlab-sandbox:ndt.downloads - referencing only recommended
 - mlab-sandbox:ndt.uploads - referencing only recommended.
 
-Each .sql file may contain a single %s, which will be replaced with
-the appropriate project name.
+Each .sql file may contain a Go text/template referencing fields of a
+bigquery.Table, e.g. `{{.ProjectID}}` which will be replaced with
+the current project name.
 
 ## Creating Views
 

--- a/views/aggregate/traceroute.sql
+++ b/views/aggregate/traceroute.sql
@@ -1,4 +1,4 @@
 #standardSQL
 -- This is the traceroute root view for historical traceroute data.
 SELECT CAST(_PARTITIONTIME AS DATE) AS partition_date, *
-FROM `%s.base_tables.traceroute`
+FROM `{{.ProjectID}}.base_tables.traceroute`

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -42,7 +42,12 @@ function create_view() {
   description+=$'\n'$'\n'"Release tag: $TRAVIS_TAG     Commit: $TRAVIS_COMMIT"
   description+=$'\n'"View of data from '${src_project}'."
 
-  dataset_table_fmt=$( grep 'FROM' ${template} | awk -F\` '{print $2}' )
+  # TODO: perform table template construction in bq_create_view.
+  dataset_table_fmt=$(
+    grep 'FROM' ${template} \
+    | head -1 \
+    | awk -F\` '{print $2}' \
+    | sed 's|{{.ProjectID}}|%s|g' )
   project_dataset_table=$( printf "${dataset_table_fmt}" "${src_project}" )
 
   # Strip filename down to view name.

--- a/views/ndt/referenced-by/recommended.sql
+++ b/views/ndt/referenced-by/recommended.sql
@@ -6,7 +6,7 @@
 --  TCP end state is sensible
 --  Test duration was between 9 and 60 seconds.
 SELECT * 
-FROM `%s.ndt.web100`
+FROM `{{.ProjectID}}.ndt.web100`
 WHERE
   -- not blacklisted
   (blacklist_flags = 0 OR

--- a/views/ndt/referenced-by/referenced-by/downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/downloads.sql
@@ -18,7 +18,7 @@ SELECT
          web100_log_entry.snap.SndLimTimeCwnd +
          web100_log_entry.snap.SndLimTimeSnd)) AS mean_download_throughput_mbps
       ) as alpha
-FROM `%s.ndt.recommended`
+FROM `{{.ProjectID}}.ndt.recommended`
 WHERE
   -- download direction, and at least 8KB transfered
   connection_spec.data_direction IS NOT NULL

--- a/views/ndt/referenced-by/referenced-by/uploads.sql
+++ b/views/ndt/referenced-by/referenced-by/uploads.sql
@@ -1,7 +1,7 @@
 #standardSQL
 --  good quality upload tests
 SELECT *
-FROM `%s.ndt.recommended`
+FROM `{{.ProjectID}}.ndt.recommended`
 WHERE
   -- is upload
   connection_spec.data_direction IS NOT NULL

--- a/views/ndt/web100.sql
+++ b/views/ndt/web100.sql
@@ -1,4 +1,4 @@
 #standardSQL
 -- This is the ndt root view that all other views in the ndt dataset are derived from.
 SELECT CAST(_PARTITIONTIME AS DATE) AS partition_date, *
-FROM `%s.base_tables.ndt`
+FROM `{{.ProjectID}}.base_tables.ndt`

--- a/views/sidestream/web100.sql
+++ b/views/sidestream/web100.sql
@@ -1,4 +1,4 @@
 #standardSQL
 -- This is the sidestream root view that all other views in the sidestream dataset are derived from.
 SELECT CAST(_PARTITIONTIME AS DATE) AS partition_date, *
-FROM `%s.base_tables.sidestream`
+FROM `{{.ProjectID}}.base_tables.sidestream`

--- a/views/utilization/switch.sql
+++ b/views/utilization/switch.sql
@@ -1,4 +1,4 @@
 #standardSQL
 -- This is the utilization root view of the switch dataset.
 SELECT CAST(_PARTITIONTIME AS DATE) AS partition_date, *
-FROM `%s.base_tables.switch`
+FROM `{{.ProjectID}}.base_tables.switch`


### PR DESCRIPTION
This change updates the views/ files to use Go text/template syntax in order to refer to the target table fields such as `ProjectID`. This change allows subqueries to refer to the same `.ProjectID` multiple times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/39)
<!-- Reviewable:end -->
