### PR TITLE
Update unified views to better align with the new parsers and gardner

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -63,13 +63,13 @@ function create_view() {
 
 
 # For each directory in the current directory.
-for DATASET_DIR in $( find -maxdepth 1 -type d -a -not -name "." ) ; do
+for DATASET_DIR in $( find -maxdepth 1 -type d -a -not -name "." | sort ) ; do
   pushd $DATASET_DIR &> /dev/null
 
     DATASET=${DATASET_DIR##./}
 
     # Create top level views. These reference tables in the "SRC_PROJECT".
-    for TEMPLATE in $( find -maxdepth 1 -name "*.sql" ) ; do
+    for TEMPLATE in $( find -maxdepth 1 -name "*.sql" | sort ) ; do
 
       create_view "${SRC_PROJECT}" "${DST_PROJECT}" "${DATASET}" "${TEMPLATE}"
     done

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -79,7 +79,8 @@ for DATASET_DIR in $( find -maxdepth 1 -type d -a -not -name "." ) ; do
     while [[ -d "referenced-by" ]] ; do
 
       cd referenced-by
-      for TEMPLATE in $( find -maxdepth 1 -name "*.sql" ) ; do
+      # TODO(etl-schema/issues/78) - dont us sort
+      for TEMPLATE in $( find -maxdepth 1 -name "*.sql" | sort ) ; do
 
         create_view "${DST_PROJECT}" "${DST_PROJECT}" "${DATASET}" "${TEMPLATE}"
       done

--- a/views/library/referenced-by/ndt_unified_ndt5_downloads.sql
+++ b/views/library/referenced-by/ndt_unified_ndt5_downloads.sql
@@ -15,6 +15,8 @@ WITH ndt5downloads AS (
   FROM   `mlab-oti.ndt.ndt5`
   -- Limit to valid S2C results
   WHERE result.S2C IS NOT NULL
+  AND result.S2C.UUID IS NOT NULL
+  AND result.S2C.UUID NOT IN ( '', 'ERROR_DISCOVERING_UUID' )
 ),
 
 tcpinfo AS (
@@ -25,8 +27,6 @@ tcpinfo AS (
 PreCleanNDT5 AS (
   SELECT
     downloads.*, tcpinfo.Client, tcpinfo.Server,
-    tcpinfo.ParseInfo AS TCPParseInfo,
-    downloads.ParseInfo AS NDT5ParseInfo,
     tcpinfo.FinalSnapshot AS FinalSnapshot,
     -- Any loss implys a netowork bottleneck
     (FinalSnapshot.TCPInfo.TotalRetrans > 0) AS IsCongested,
@@ -49,25 +49,28 @@ PreCleanNDT5 AS (
                 12) = NET.IP_FROM_STRING("172.16.0.0"))
       OR (NET.IP_TRUNC(NET.SAFE_IP_FROM_STRING(downloads.S2C.ServerIP),
                 16) = NET.IP_FROM_STRING("192.168.0.0"))
-    ) AS IsOAM  -- Data is not from valid clients
+    ) AS IsOAM,  -- Data is not from valid clients
+    tcpinfo.ParseInfo AS TCPparser,
+    downloads.ParseInfo AS NDT5parser,
   FROM
     -- Use a left join to allow NDT test without matching tcpinfo rows.
     ndt5downloads AS downloads
     LEFT JOIN tcpinfo
     ON
-#    downloads.partition_date = tcpinfo.partition_date AND -- why does this exclude rows? issue:#63
-     downloads.S2C.UUID = tcpinfo.UUID
+      downloads.partition_date = tcpinfo.partition_date -- This may exclude a few rows issue:#63
+      AND downloads.S2C.UUID = tcpinfo.UUID
 ),
 
 NDT5DownloadModels AS (
   SELECT
-    partition_date as test_date,
+    S2C.UUID AS id,
+    partition_date as test_date, -- rename to date
     STRUCT (
       -- NDT unified fields: Upload/Download/RTT/Loss/CCAlg + Geo + ASN
       S2C.UUID,
       S2C.StartTime AS TestTime,
       FinalSnapshot.CongestionAlgorithm AS CongestionControl,
-      S2C.MeanThroughputMbps,
+      S2C.MeanThroughputMbps AS MeanThroughputMbps,
       S2C.MinRTT/1000000.0 AS MinRTT, -- units are ms
       SAFE_DIVIDE(FinalSnapshot.TCPInfo.BytesRetrans, FinalSnapshot.TCPInfo.BytesSent) AS LossRate
     ) AS a,
@@ -109,12 +112,22 @@ NDT5DownloadModels AS (
     STRUCT (
       S2C.ServerIP AS IP,
       S2C.ServerPort AS Port,
+      REGEXP_EXTRACT(ParseInfo.TaskFileName,
+            'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
+      REGEXP_EXTRACT(ParseInfo.TaskFileName,
+            '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
       Server.Geo,
       STRUCT(
         CAST (Server.Network.Systems[OFFSET(0)].ASNs[OFFSET(0)] AS STRING) AS ASNumber
       ) AS Network
     ) AS server,
-    PreCleanNDT5 AS _internal202004  -- Not stable and subject to breaking changes
+    STRUCT (
+       ParseInfo.ParserVersion AS Version,
+       ParseInfo.ParseTime AS Time,
+       ParseInfo.TaskFileName AS ArchiveURL,
+       S2C.UUID AS Filename
+    ) AS _parser,
+    PreCleanNDT5 AS _internal202006  -- Not stable and subject to breaking changes
   FROM PreCleanNDT5
 )
 

--- a/views/library/referenced-by/ndt_unified_ndt5_downloads.sql
+++ b/views/library/referenced-by/ndt_unified_ndt5_downloads.sql
@@ -57,8 +57,8 @@ PreCleanNDT5 AS (
     ndt5downloads AS downloads
     LEFT JOIN tcpinfo
     ON
-      downloads.partition_date = tcpinfo.partition_date -- This may exclude a few rows issue:#63
-      AND downloads.S2C.UUID = tcpinfo.UUID
+#     downloads.partition_date = tcpinfo.partition_date AND -- This may exclude a few rows issue:#63
+      downloads.S2C.UUID = tcpinfo.UUID
 ),
 
 NDT5DownloadModels AS (
@@ -121,12 +121,6 @@ NDT5DownloadModels AS (
         CAST (Server.Network.Systems[OFFSET(0)].ASNs[OFFSET(0)] AS STRING) AS ASNumber
       ) AS Network
     ) AS server,
-    STRUCT (
-       ParseInfo.ParserVersion AS Version,
-       ParseInfo.ParseTime AS Time,
-       ParseInfo.TaskFileName AS ArchiveURL,
-       S2C.UUID AS Filename
-    ) AS _parser,
     PreCleanNDT5 AS _internal202006  -- Not stable and subject to breaking changes
   FROM PreCleanNDT5
 )

--- a/views/library/referenced-by/ndt_unified_ndt5_uploads.sql
+++ b/views/library/referenced-by/ndt_unified_ndt5_uploads.sql
@@ -52,8 +52,8 @@ PreCleanNDT5 AS (
     ndt5uploads AS uploads
     LEFT JOIN tcpinfo
     ON
-      uploads.partition_date = tcpinfo.partition_date  -- This may exclude a few rows issue:#63
-      AND uploads.C2S.UUID = tcpinfo.UUID
+#     uploads.partition_date = tcpinfo.partition_date AND -- This may exclude a few rows issue:#63
+      uploads.C2S.UUID = tcpinfo.UUID
 ),
 
 NDT5UploadModels AS (

--- a/views/library/referenced-by/ndt_unified_ndt5_uploads.sql
+++ b/views/library/referenced-by/ndt_unified_ndt5_uploads.sql
@@ -9,12 +9,13 @@
 --
 
 WITH ndt5uploads AS (
-  SELECT partition_date, result.C2S,
-  (result.C2S.Error != "") AS b_HasError,
+  SELECT partition_date, ParseInfo, result.C2S,
+  (result.C2S.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(result.C2S.EndTime, result.C2S.StartTime, MICROSECOND) AS connection_duration
   FROM   `mlab-oti.ndt.ndt5`
   -- Limit to valid C2S results
   WHERE  result.C2S IS NOT NULL
+  AND result.C2S.UUID NOT IN ( '', 'ERROR_DISCOVERING_UUID' )
 ),
 
 tcpinfo AS (
@@ -43,19 +44,22 @@ PreCleanNDT5 AS (
                 12) = NET.IP_FROM_STRING("172.16.0.0"))
       OR (NET.IP_TRUNC(NET.SAFE_IP_FROM_STRING(uploads.C2S.ServerIP),
                 16) = NET.IP_FROM_STRING("192.168.0.0"))
-    ) AS b_OAM  -- Data is not from valid clients
- FROM
+    ) AS IsOAM,  -- Data is not from valid clients
+    tcpinfo.ParseInfo AS TCPparser,
+    uploads.ParseInfo AS NDT5parser,
+  FROM
     -- Use a left join to allow NDT test without matching tcpinfo rows.
     ndt5uploads AS uploads
     LEFT JOIN tcpinfo
     ON
-#    uploads.partition_date = tcpinfo.partition_date AND -- why does this exclude rows? issue:#63
-     uploads.C2S.UUID = tcpinfo.UUID
+      uploads.partition_date = tcpinfo.partition_date  -- This may exclude a few rows issue:#63
+      AND uploads.C2S.UUID = tcpinfo.UUID
 ),
 
 NDT5UploadModels AS (
   SELECT
-    partition_date as test_date,
+    C2S.UUID AS id,
+    partition_date as test_date, -- rename to date
     STRUCT (
       -- NDT unified fields: Upload/Download/RTT/Loss/CCAlg + Geo + ASN
       C2S.UUID,
@@ -63,21 +67,21 @@ NDT5UploadModels AS (
       FinalSnapshot.CongestionAlgorithm AS CongestionControl,
       C2S.MeanThroughputMbps AS MeanThroughputMbps,
       FinalSnapshot.TCPInfo.MinRTT/1000.0 AS MinRTT, -- Sender's MinRTT (ms)
-      0 AS LossRate  -- Receiver can not disambiguate reordering and loss
+      Null AS LossRate  -- Receiver can not disambiguate reordering and loss
     ) AS a,
     STRUCT (
      "tcpinfo" AS _Instruments -- THIS WILL CHANGE
     ) AS node,
     -- Struct filter has predicates for various cleaning assumptions
     STRUCT (
-      ( -- Many Filters are built into the parser
-        NOT b_OAM AND NOT b_HasError
+      (  -- No C2S test for client vs network bottleneck
+        NOT IsOAM AND NOT IsErrored
         AND FinalSnapshot.TCPInfo.BytesReceived IS NOT NULL
         AND FinalSnapshot.TCPInfo.BytesReceived >= 8192
         AND connection_duration BETWEEN 9000000 AND 60000000
       ) AS IsValidBest,
-      ( -- Losses > 0 make no sense for C2S
-        NOT b_OAM AND NOT b_HasError
+      (  -- No C2S test for client vs network bottleneck
+        NOT IsOAM AND NOT IsErrored
         AND FinalSnapshot.TCPInfo.BytesReceived IS NOT NULL
         AND FinalSnapshot.TCPInfo.BytesReceived >= 8192
         AND connection_duration BETWEEN 9000000 AND 60000000
@@ -101,12 +105,16 @@ NDT5UploadModels AS (
     STRUCT (
       C2S.ServerIP AS IP,
       C2S.ServerPort AS Port,
+      REGEXP_EXTRACT(ParseInfo.TaskFileName,
+            'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
+      REGEXP_EXTRACT(ParseInfo.TaskFileName,
+            '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
       Server.Geo,
       STRUCT(
         CAST (Server.Network.Systems[OFFSET(0)].ASNs[OFFSET(0)] AS STRING) AS ASNumber
       ) AS Network
     ) AS server,
-    PreCleanNDT5 AS _internal202004  -- Not stable and subject to breaking changes
+    PreCleanNDT5 AS _internal202006  -- Not stable and subject to breaking changes
   FROM PreCleanNDT5
 )
 

--- a/views/library/referenced-by/ndt_unified_web100_downloads.sql
+++ b/views/library/referenced-by/ndt_unified_web100_downloads.sql
@@ -39,7 +39,13 @@ WITH PreCleanWeb100 AS (
      ) AS IsOAM,  -- Data is not from valid clients
      web100_log_entry.snap.OctetsRetrans > 0 AS IsCongested,
      (  web100_log_entry.snap.SmoothedRTT > 2*web100_log_entry.snap.MinRTT AND
-        web100_log_entry.snap.SmoothedRTT > 1000 ) AS IsBloated
+        web100_log_entry.snap.SmoothedRTT > 1000 ) AS IsBloated,
+    STRUCT (
+      parser_version AS Version,
+      parse_time AS Time,
+      task_filename AS ArchiveURL,
+      "web100" AS Filename
+    ) AS Web100parser,
   FROM `mlab-oti.ndt.web100`
   WHERE
     web100_log_entry.snap.Duration IS NOT NULL
@@ -51,9 +57,10 @@ WITH PreCleanWeb100 AS (
     AND web100_log_entry.snap.SndLimTimeSnd IS NOT NULL
 ),
 
-       Web100DownloadModels AS (
+Web100DownloadModels AS (
   SELECT
-    test_date,
+     psuedoUUID as id,
+     test_date, -- Rename to date
     -- Struct a models various TCP behaviors
     STRUCT(
       psuedoUUID as UUID,
@@ -114,6 +121,10 @@ WITH PreCleanWeb100 AS (
     STRUCT (
       web100_log_entry.connection_spec.local_ip AS IP,
       web100_log_entry.connection_spec.local_port AS Port,
+      REGEXP_EXTRACT(task_filename,
+            'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
+      REGEXP_EXTRACT(task_filename,
+            '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
       STRUCT(
         connection_spec.server_geolocation.continent_code,
         connection_spec.server_geolocation.country_code,
@@ -132,7 +143,7 @@ WITH PreCleanWeb100 AS (
         connection_spec.server.network.asn AS ASNumber
       ) AS Network
     ) AS server,
-    PreCleanWeb100 AS _internal202004  -- Not stable and subject to breaking changes
+    PreCleanWeb100 AS _internal202006  -- Not stable and subject to breaking changes
   FROM PreCleanWeb100
   WHERE
     measurement_duration > 0 AND connection_duration > 0

--- a/views/library/referenced-by/ndt_unified_web100_downloads.sql
+++ b/views/library/referenced-by/ndt_unified_web100_downloads.sql
@@ -19,7 +19,7 @@ WITH PreCleanWeb100 AS (
       web100_log_entry.connection_spec.remote_ip,
       CAST (web100_log_entry.connection_spec.remote_port AS STRING),
       CAST (partition_date AS STRING)
-    ) AS psuedoUUID,
+    ) AS pseudoUUID,
     *,
     web100_log_entry.snap.Duration AS connection_duration, -- SYN to FIN total time
     (web100_log_entry.snap.SndLimTimeRwin +
@@ -59,11 +59,11 @@ WITH PreCleanWeb100 AS (
 
 Web100DownloadModels AS (
   SELECT
-     psuedoUUID as id,
+     pseudoUUID as id,
      test_date, -- Rename to date
     -- Struct a models various TCP behaviors
     STRUCT(
-      psuedoUUID as UUID,
+      pseudoUUID as UUID,
       log_time AS TestTime,
       "reno" AS CongestionControl,
       web100_log_entry.snap.HCThruOctetsAcked * 8.0 / measurement_duration AS MeanThroughputMbps,

--- a/views/library/referenced-by/ndt_unified_web100_uploads.sql
+++ b/views/library/referenced-by/ndt_unified_web100_uploads.sql
@@ -19,7 +19,7 @@ WITH PreCleanWeb100 AS (
       web100_log_entry.connection_spec.remote_ip,
       CAST (web100_log_entry.connection_spec.remote_port AS STRING),
       CAST (partition_date AS STRING)
-    ) AS psuedoUUID,
+    ) AS pseudoUUID,
     *,
     web100_log_entry.snap.Duration AS connection_duration, -- SYN to FIN total time
     IF(web100_log_entry.snap.Duration > 12000000,   /* 12 sec */
@@ -38,7 +38,7 @@ WITH PreCleanWeb100 AS (
                 16) = NET.IP_FROM_STRING("192.168.0.0"))
      ) AS IsOAM,  -- Data is not from valid clients
      ( -- Eliminate some clearly bogus data
-	 web100_log_entry.snap.HCThruOctetsReceived > 1E14 -- approximately 10Gb/s for 24 hours
+       web100_log_entry.snap.HCThruOctetsReceived > 1E14 -- approximately 10Gb/s for 24 hours
      ) AS IsCorrupted,
     STRUCT (
       parser_version AS Version,
@@ -59,11 +59,11 @@ WITH PreCleanWeb100 AS (
 
 Web100UploadModels AS (
   SELECT
-    psuedoUUID as id,
+    pseudoUUID as id,
     test_date, -- Rename to date
     -- Struct a models various TCP behaviors
     STRUCT(
-      psuedoUUID as UUID,
+      pseudoUUID as UUID,
       log_time AS TestTime,
       "reno" AS CongestionControl,
       web100_log_entry.snap.HCThruOctetsReceived * 8.0 / connection_duration AS MeanThroughputMbps,

--- a/views/ndt/referenced-by/referenced-by/unified_downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/unified_downloads.sql
@@ -37,10 +37,10 @@
 
 SELECT * EXCEPT (filter)
 FROM (
-    SELECT test_date, a, filter, node, client, server
+    SELECT id, test_date, a, filter, node, client, server
     FROM `{{.ProjectID}}.library.ndt_unified_ndt5_downloads`
   UNION ALL
-    SELECT test_date, a, filter, node, client, server
+    SELECT id, test_date, a, filter, node, client, server
     FROM `{{.ProjectID}}.library.ndt_unified_web100_downloads`
 )
 WHERE

--- a/views/ndt/referenced-by/referenced-by/unified_downloads.sql
+++ b/views/ndt/referenced-by/referenced-by/unified_downloads.sql
@@ -34,13 +34,14 @@
 -- We do not consider changes to our constituent views to be breaking
 -- changes if the changes are fully masked by our unified views.
 --
-
+-- NB: deprecate test_date in favor of date
+--
 SELECT * EXCEPT (filter)
 FROM (
-    SELECT id, test_date, a, filter, node, client, server
+    SELECT id, test_date AS date, a, filter, node, client, server, test_date
     FROM `{{.ProjectID}}.library.ndt_unified_ndt5_downloads`
   UNION ALL
-    SELECT id, test_date, a, filter, node, client, server
+    SELECT id, test_date AS date, a, filter, node, client, server, test_date
     FROM `{{.ProjectID}}.library.ndt_unified_web100_downloads`
 )
 WHERE

--- a/views/ndt/referenced-by/referenced-by/unified_uploads.sql
+++ b/views/ndt/referenced-by/referenced-by/unified_uploads.sql
@@ -35,10 +35,10 @@
 --
 SELECT * EXCEPT (filter)
 FROM (
-    SELECT test_date, a, filter, node, client, server
+    SELECT id, test_date, a, filter, node, client, server
     FROM `{{.ProjectID}}.library.ndt_unified_ndt5_uploads`
   UNION ALL
-    SELECT test_date, a, filter, node, client, server
+    SELECT id, test_date, a, filter, node, client, server
     FROM `{{.ProjectID}}.library.ndt_unified_web100_uploads`
 )
 WHERE

--- a/views/ndt/referenced-by/referenced-by/unified_uploads.sql
+++ b/views/ndt/referenced-by/referenced-by/unified_uploads.sql
@@ -33,12 +33,14 @@
 -- We do not consider changes to our constituent views to be breaking
 -- changes if the changes are fully masked by our unified views.
 --
+-- NB: deprecate test_date in favor of date
+--
 SELECT * EXCEPT (filter)
 FROM (
-    SELECT id, test_date, a, filter, node, client, server
+    SELECT id, test_date AS date, a, filter, node, client, server, test_date
     FROM `{{.ProjectID}}.library.ndt_unified_ndt5_uploads`
   UNION ALL
-    SELECT id, test_date, a, filter, node, client, server
+    SELECT id, test_date AS date, a, filter, node, client, server, test_date
     FROM `{{.ProjectID}}.library.ndt_unified_web100_uploads`
 )
 WHERE


### PR DESCRIPTION
These are all non-breaking for all proper queries:
    - Discard rows missing UUIDs earlier in the process (this improves join performance)
    - Restore join on partition date to the UUID join (further improve join performance)
    - Make 'id' a top level field (but no change to test_date)
    - Added server.Site and server.Machine
    - Make uncomputable upload loss rate Null (not 0)
    - Updated _internal202004 to _internal202006 (not visible in the unified views)
    - Expose parsers within _internal202006: NDT5parser, TCPparser, Web100parser
    - Exclude corrupted rows (more than 1E14 bytes received)
    - Internal cosmetic changes
    - Constrain create_dataset_views.sh to build libraries before other views

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/79)
<!-- Reviewable:end -->
