### PR TITLE
Back name geo columns to publish legacy views

### DIFF
--- a/views/intermediate_ndt/referenced-by/extended_ndt5_downloads.sql
+++ b/views/intermediate_ndt/referenced-by/extended_ndt5_downloads.sql
@@ -101,9 +101,8 @@ NDT5DownloadModels AS (
     STRUCT (
       S2C.ClientIP AS IP,
       S2C.ClientPort AS Port,
-      Client.Geo,  -- Legacy Geo is first, to be removed
       -- Legacy Geo approximates dev.maxmind.com/geoip/geoip2/geoip2-city-country-csv-databases/
-      STRUCT ( -- Future primary Geo
+      STRUCT (
              client.Geo.continent_code, -- aka ContinentCode
              client.Geo.country_code, -- aka CountryCode
              client.Geo.country_code3, -- aka CountryCode3
@@ -138,8 +137,7 @@ NDT5DownloadModels AS (
             'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
       REGEXP_EXTRACT(ParseInfo.TaskFileName,
             '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
-      Server.Geo, -- Legacy Geo is first, to be removed
-      STRUCT ( -- Future primary Geo
+      STRUCT (
              server.Geo.continent_code, -- aka ContinentCode
              server.Geo.country_code, -- aka CountryCode
              server.Geo.country_code3, -- aka CountryCode3

--- a/views/intermediate_ndt/referenced-by/extended_ndt5_uploads.sql
+++ b/views/intermediate_ndt/referenced-by/extended_ndt5_uploads.sql
@@ -94,9 +94,8 @@ NDT5UploadModels AS (
     STRUCT (
       C2S.ClientIP AS IP,
       C2S.ClientPort AS Port,
-      Client.Geo,  -- Legacy Geo is first, to be removed
       -- Legacy Geo approximates dev.maxmind.com/geoip/geoip2/geoip2-city-country-csv-databases/
-      STRUCT ( -- Future primary Geo
+      STRUCT (
              client.Geo.continent_code, -- aka ContinentCode
              client.Geo.country_code, -- aka CountryCode
              client.Geo.country_code3, -- aka CountryCode3
@@ -114,7 +113,7 @@ NDT5UploadModels AS (
              client.Geo.longitude, -- aka Longitude
              client.Geo.radius, -- aka AccuracyRadiusKm
              FALSE AS Missing -- Future missing record flag
-      ) AS _new_Geo,  -- Do not use, switch to new unified view
+      ) AS Geo,
 #      Client.Network -- BUG still old schema
       STRUCT (
         client.Network.IPPrefix AS CIDR,
@@ -131,8 +130,7 @@ NDT5UploadModels AS (
             'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
       REGEXP_EXTRACT(ParseInfo.TaskFileName,
             '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
-      Server.Geo, -- Legacy Geo is first, to be removed
-      STRUCT ( -- Future primary Geo
+      STRUCT (
              server.Geo.continent_code, -- aka ContinentCode
              server.Geo.country_code, -- aka CountryCode
              server.Geo.country_code3, -- aka CountryCode3
@@ -150,7 +148,7 @@ NDT5UploadModels AS (
              server.Geo.longitude, -- aka Longitude
              server.Geo.radius, -- aka AccuracyRadiusKm
              FALSE AS Missing -- Future missing record flag
-      ) AS _new_Geo,  -- Do not use, switch to new unified view
+      ) AS Geo,
 #     Server.Network -- BUG still old schema
       STRUCT (
         server.Network.IPPrefix AS CIDR,

--- a/views/intermediate_ndt/referenced-by/extended_ndt7_downloads.sql
+++ b/views/intermediate_ndt/referenced-by/extended_ndt7_downloads.sql
@@ -94,26 +94,6 @@ NDT7DownloadModels AS (
     STRUCT (
       raw.ClientIP AS IP,
       raw.ClientPort AS Port,
-      -- TODO Remove legacy _Geo from all views
-      STRUCT (  -- Map new geo into older production geo
-             client.Geo.ContinentCode, -- aka continent_code,
-             client.Geo.CountryCode, -- aka country_code,
-             client.Geo.CountryCode3, -- aka country_code3,
-             client.Geo.CountryName, -- aka country_name,
-             client.Geo.Region, -- aka region,
-             -- client.Geo.Subdivision1ISOCode -- OMITED
-             -- client.Geo.Subdivision1Name -- OMITED
-             -- client.Geo.Subdivision2ISOCode -- OMITED
-             -- client.Geo.Subdivision2Name -- OMITED
-             client.Geo.MetroCode, -- aka metro_code,
-             client.Geo.City, -- aka city,
-             client.Geo.AreaCode, -- aka area_code,
-             client.Geo.PostalCode, -- aka postal_code,
-             client.Geo.Latitude, -- aka latitude,
-             client.Geo.Longitude, -- aka longitude,
-             client.Geo.AccuracyRadiusKm -- aka radius
-             -- client.Geo.Missing -- Future
-      ) AS _Geo, -- Legacy
       client.Geo, -- The entire new geo struct
       client.Network
     ) AS client,
@@ -122,26 +102,6 @@ NDT7DownloadModels AS (
       raw.ServerPort AS Port,
       server.Site, -- e.g. lga02
       server.Machine, -- e.g. mlab1
-      -- TODO Remove legacy _Geo from all views
-      STRUCT (  -- Map new geo into legacy production geo
-             server.Geo.ContinentCode, -- aka continent_code,
-             server.Geo.CountryCode, -- aka country_code,
-             server.Geo.CountryCode3, -- aka country_code3,
-             server.Geo.CountryName, -- aka country_name,
-             server.Geo.Region, -- aka region,
-             -- server.Geo. Subdivision1ISOCode -- OMITED
-             -- server.Geo. Subdivision1Name -- OMITED
-             -- server.Geo.Subdivision2ISOCode -- OMITED
-             -- server.Geo.Subdivision2Name -- OMITED
-             server.Geo.MetroCode, -- aka metro_code,
-             server.Geo.City, -- aka city,
-             server.Geo.AreaCode, -- aka area_code,
-             server.Geo.PostalCode, -- aka postal_code,
-             server.Geo.Latitude, -- aka latitude,
-             server.Geo.Longitude, -- aka longitude,
-             server.Geo.AccuracyRadiusKm -- aka radius
-             -- server.Geo.Missing -- Future
-      ) AS _Geo, -- Legacy
       server.Geo,
       server.Network
     ) AS server,

--- a/views/intermediate_ndt/referenced-by/extended_ndt7_uploads.sql
+++ b/views/intermediate_ndt/referenced-by/extended_ndt7_uploads.sql
@@ -89,27 +89,7 @@ NDT7UploadModels AS (
     STRUCT (
       raw.ClientIP AS IP,
       raw.ClientPort AS Port,
-      -- TODO Remove legacy _Geo from all views
-      STRUCT (  -- Map new geo into older production geo
-             client.Geo.ContinentCode, -- aka continent_code,
-             client.Geo.CountryCode, -- aka country_code,
-             client.Geo.CountryCode3, -- aka country_code3,
-             client.Geo.CountryName, -- aka country_name,
-             client.Geo.Region, -- aka region,
-             -- client.Geo.Subdivision1ISOCode -- OMITED
-             -- client.Geo.Subdivision1Name -- OMITED
-             -- client.Geo.Subdivision2ISOCode -- OMITED
-             -- client.Geo.Subdivision2Name -- OMITED
-             client.Geo.MetroCode, -- aka metro_code,
-             client.Geo.City, -- aka city,
-             client.Geo.AreaCode, -- aka area_code,
-             client.Geo.PostalCode, -- aka postal_code,
-             client.Geo.Latitude, -- aka latitude,
-             client.Geo.Longitude, -- aka longitude,
-             client.Geo.AccuracyRadiusKm -- aka radius
-             -- client.Geo.Missing -- Future
-      ) AS _Geo, -- Legacy
-      client.Geo, -- The entire new geo struct
+      client.Geo,
       client.Network
     ) AS client,
     STRUCT (
@@ -117,26 +97,6 @@ NDT7UploadModels AS (
       raw.ServerPort AS Port,
       server.Site, -- e.g. lga02
       server.Machine, -- e.g. mlab1
-      -- TODO Remove legacy _Geo from all views
-      STRUCT (  -- Map new geo into legacy production geo
-             server.Geo.ContinentCode, -- aka continent_code,
-             server.Geo.CountryCode, -- aka country_code,
-             server.Geo.CountryCode3, -- aka country_code3,
-             server.Geo.CountryName, -- aka country_name,
-             server.Geo.Region, -- aka region,
-             -- server.Geo. Subdivision1ISOCode -- OMITED
-             -- server.Geo. Subdivision1Name -- OMITED
-             -- server.Geo.Subdivision2ISOCode -- OMITED
-             -- server.Geo.Subdivision2Name -- OMITED
-             server.Geo.MetroCode, -- aka metro_code,
-             server.Geo.City, -- aka city,
-             server.Geo.AreaCode, -- aka area_code,
-             server.Geo.PostalCode, -- aka postal_code,
-             server.Geo.Latitude, -- aka latitude,
-             server.Geo.Longitude, -- aka longitude,
-             server.Geo.AccuracyRadiusKm -- aka radius
-             -- server.Geo.Missing -- Future
-      ) AS _Geo, -- Legacy
       server.Geo,
       server.Network
     ) AS server,

--- a/views/intermediate_ndt/referenced-by/extended_web100_downloads.sql
+++ b/views/intermediate_ndt/referenced-by/extended_web100_downloads.sql
@@ -97,24 +97,7 @@ Web100DownloadModels AS (
     STRUCT (
       web100_log_entry.connection_spec.remote_ip AS IP,
       web100_log_entry.connection_spec.remote_port AS Port,
-      STRUCT(   -- Legacy Geo is first, to be removed
-        -- NOTE: it's necessary to enumerate each field because the new Server.Geo
-        -- fields are in a different order. Here reorder the web100 fields because
-        -- we accept the newer tables as the canonical ordering.
-        connection_spec.client_geolocation.continent_code,
-        connection_spec.client_geolocation.country_code,
-        connection_spec.client_geolocation.country_code3,
-        connection_spec.client_geolocation.country_name,
-        connection_spec.client_geolocation.region,
-        connection_spec.client_geolocation.metro_code,
-        connection_spec.client_geolocation.city,
-        connection_spec.client_geolocation.area_code,
-        connection_spec.client_geolocation.postal_code,
-        connection_spec.client_geolocation.latitude,
-        connection_spec.client_geolocation.longitude,
-        connection_spec.client_geolocation.radius
-      ) AS Geo, -- Legacy Geo
-      STRUCT( -- Future primary Geo
+      STRUCT(
         -- NOTE: it's necessary to enumerate each field because the new Server.Geo
         -- fields are in a different order. Here reorder the web100 fields because
         -- we accept the newer tables as the canonical ordering.
@@ -135,7 +118,7 @@ Web100DownloadModels AS (
         connection_spec.client_geolocation.longitude,
         connection_spec.client_geolocation.radius,
         True AS Missing -- Future missing record flag
-      ) AS _new_Geo,  -- Do not use, switch to new unified view
+      ) AS Geo,
       STRUCT(
         '' AS CIDR,
         SAFE_CAST(connection_spec.client.network.asn AS INT64) AS ASNumber,
@@ -151,21 +134,7 @@ Web100DownloadModels AS (
             'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
       REGEXP_EXTRACT(task_filename,
             '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
-      STRUCT(   -- Legacy Geo is first, to be removed
-        connection_spec.server_geolocation.continent_code,
-        connection_spec.server_geolocation.country_code,
-        connection_spec.server_geolocation.country_code3,
-        connection_spec.server_geolocation.country_name,
-        connection_spec.server_geolocation.region,
-        connection_spec.server_geolocation.metro_code,
-        connection_spec.server_geolocation.city,
-        connection_spec.server_geolocation.area_code,
-        connection_spec.server_geolocation.postal_code,
-        connection_spec.server_geolocation.latitude,
-        connection_spec.server_geolocation.longitude,
-        connection_spec.server_geolocation.radius
-      ) AS Geo,  -- Legacy Geo
-      STRUCT( -- Future primary Geo
+      STRUCT(
         -- NOTE: it's necessary to enumerate each field because the new Server.Geo
         -- fields are in a different order. Here reorder the web100 fields because
         -- we accept the newer tables as the canonical ordering.
@@ -186,7 +155,7 @@ Web100DownloadModels AS (
         connection_spec.server_geolocation.longitude,
         connection_spec.server_geolocation.radius,
         True AS Missing -- Future missing record flag
-      ) AS _new_Geo,  -- Do not use, switch to new unified view
+      ) AS Geo,
       STRUCT(
         '' AS CIDR,
         SAFE_CAST(connection_spec.server.network.asn AS INT64) AS ASNumber,

--- a/views/intermediate_ndt/referenced-by/extended_web100_uploads.sql
+++ b/views/intermediate_ndt/referenced-by/extended_web100_uploads.sql
@@ -95,24 +95,7 @@ Web100UploadModels AS (
     STRUCT (
       web100_log_entry.connection_spec.remote_ip AS IP,
       web100_log_entry.connection_spec.remote_port AS Port,
-      STRUCT(   -- Legacy Geo is first, to be removed
-        -- NOTE: it's necessary to enumerate each field because the new Server.Geo
-        -- fields are in a different order. Here reorder the web100 fields because
-        -- we accept the newer tables as the canonical ordering.
-        connection_spec.client_geolocation.continent_code,
-        connection_spec.client_geolocation.country_code,
-        connection_spec.client_geolocation.country_code3,
-        connection_spec.client_geolocation.country_name,
-        connection_spec.client_geolocation.region,
-        connection_spec.client_geolocation.metro_code,
-        connection_spec.client_geolocation.city,
-        connection_spec.client_geolocation.area_code,
-        connection_spec.client_geolocation.postal_code,
-        connection_spec.client_geolocation.latitude,
-        connection_spec.client_geolocation.longitude,
-        connection_spec.client_geolocation.radius
-      ) AS Geo, -- Legacy Geo
-      STRUCT( -- Future primary Geo
+      STRUCT(
         -- NOTE: it's necessary to enumerate each field because the new Server.Geo
         -- fields are in a different order. Here reorder the web100 fields because
         -- we accept the newer tables as the canonical ordering.
@@ -133,7 +116,7 @@ Web100UploadModels AS (
         connection_spec.client_geolocation.longitude,
         connection_spec.client_geolocation.radius,
         True AS Missing -- Future missing record flag
-      ) AS _new_Geo,  -- Do not use, switch to new unified view
+      ) AS Geo,
       STRUCT(
         '' AS CIDR,
         SAFE_CAST(connection_spec.client.network.asn AS INT64) AS ASNumber,
@@ -149,21 +132,7 @@ Web100UploadModels AS (
             'mlab[1-4]-([a-z][a-z][a-z][0-9][0-9t])') AS Site, -- e.g. lga02
       REGEXP_EXTRACT(task_filename,
             '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') AS Machine, -- e.g. mlab1
-      STRUCT(   -- Legacy Geo is first, to be removed
-        connection_spec.server_geolocation.continent_code,
-        connection_spec.server_geolocation.country_code,
-        connection_spec.server_geolocation.country_code3,
-        connection_spec.server_geolocation.country_name,
-        connection_spec.server_geolocation.region,
-        connection_spec.server_geolocation.metro_code,
-        connection_spec.server_geolocation.city,
-        connection_spec.server_geolocation.area_code,
-        connection_spec.server_geolocation.postal_code,
-        connection_spec.server_geolocation.latitude,
-        connection_spec.server_geolocation.longitude,
-        connection_spec.server_geolocation.radius
-      ) AS Geo,  -- Legacy Geo
-      STRUCT( -- Future primary Geo
+      STRUCT(
         -- NOTE: it's necessary to enumerate each field because the new Server.Geo
         -- fields are in a different order. Here reorder the web100 fields because
         -- we accept the newer tables as the canonical ordering.
@@ -184,7 +153,7 @@ Web100UploadModels AS (
         connection_spec.server_geolocation.longitude,
         connection_spec.server_geolocation.radius,
         True AS Missing -- Future missing record flag
-      ) AS _new_Geo,  -- Do not use, switch to new unified view
+      ) AS Geo,
       STRUCT(
         '' AS CIDR,
         SAFE_CAST(connection_spec.server.network.asn AS INT64) AS ASNumber,

--- a/views/ndt/referenced-by/referenced-by/unified_downloads_20201026x.sql
+++ b/views/ndt/referenced-by/referenced-by/unified_downloads_20201026x.sql
@@ -27,21 +27,57 @@
 --       longitude to Longitude
 --          radius to AccuracyRadiusKm
 --
-SELECT *
-EXCEPT (filter)
-FROM (
-    -- NB: reordering UNION clauses may cause breaking changes to field names
-    -- 2019-07-18 to present
-    SELECT id, date, a, filter, node, client, server, date AS test_date
-    FROM `{{.ProjectID}}.intermediate_ndt.extended_ndt5_downloads`
-  UNION ALL
-    -- 2020-03-12 to present
-    SELECT id, date, a, filter, node, client, server, date AS test_date
-    FROM `{{.ProjectID}}.intermediate_ndt.extended_ndt7_downloads`
-  UNION ALL
-    -- 2009-02-18 to 2019-11-20
-    SELECT id, date, a, filter, node, client, server, date AS test_date
-    FROM `{{.ProjectID}}.intermediate_ndt.extended_web100_downloads`
-)
-WHERE
-  filter.IsValidBest
+SELECT
+  id, date, a, node,
+  STRUCT (
+    client.IP,
+    client.Port,
+    STRUCT (  -- Map new geo into older production geo
+      client.Geo.ContinentCode AS continent_code,
+      client.Geo.CountryCode AS country_code,
+      client.Geo.CountryCode3 AS country_code3,
+      client.Geo.CountryName AS country_name,
+      client.Geo.Region AS region,
+      -- client.Geo. Subdivision1ISOCode -- OMITED
+      -- client.Geo. Subdivision1Name -- OMITED
+      -- client.Geo.Subdivision2ISOCode -- OMITED
+      -- client.Geo.Subdivision2Name -- OMITED
+      client.Geo.MetroCode AS metro_code,
+      client.Geo.City AS city,
+      client.Geo.AreaCode AS area_code,
+      client.Geo.PostalCode AS postal_code,
+      client.Geo.Latitude AS latitude,
+      client.Geo.Longitude AS longitude,
+      client.Geo.AccuracyRadiusKm AS radius
+      -- client.Geo.Missing -- Future
+    ) AS Geo,
+    client.Network
+  ) as client,
+  STRUCT (
+    server.IP,
+    server.Port,
+    server.Site,
+    server.Machine,
+    STRUCT (  -- Map new geo into older production geo
+      server.Geo.ContinentCode AS continent_code,
+      server.Geo.CountryCode AS country_code,
+      server.Geo.CountryCode3 AS country_code3,
+      server.Geo.CountryName AS country_name,
+      server.Geo.Region AS region,
+      -- server.Geo. Subdivision1ISOCode -- OMITED
+      -- server.Geo. Subdivision1Name -- OMITED
+      -- server.Geo.Subdivision2ISOCode -- OMITED
+      -- server.Geo.Subdivision2Name -- OMITED
+      server.Geo.MetroCode AS metro_code,
+      server.Geo.City AS city,
+      server.Geo.AreaCode AS area_code,
+      server.Geo.PostalCode AS postal_code,
+      server.Geo.Latitude AS latitude,
+      server.Geo.Longitude AS longitude,
+      server.Geo.AccuracyRadiusKm AS radius
+      -- server.Geo.Missing -- Future
+    ) AS Geo,
+    server.Network
+  ) as server,
+  date as test_date
+FROM `{{.ProjectID}}.ndt.unified_downloads`


### PR DESCRIPTION
This uses a different method to provide support for legacy Geo column names. By hindsite it is simpler, but may not be generalizable to other situations.

To get the build sequence correct, this does depend on underscore lexicographically sorting after dot.
 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/93)
<!-- Reviewable:end -->
