### PR TITLE
Update stats queries with corrected script

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -117,18 +117,18 @@ create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hou
 create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_uploads_before.sql
 
 # stats-pipeline
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_global_asn.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_continents.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_continents_asn.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_countries.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_countries_asn.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_regions.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_regions_asn.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_cities.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_cities_asn.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states_asn.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_global_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_continents.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_continents_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_countries.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_countries_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_regions.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_regions_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_cities.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_cities_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties_asn.sql
 
 echo "All views created successfully"

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -117,18 +117,18 @@ create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hou
 create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_uploads_before.sql
 
 # stats-pipeline
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_global_asn.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_continents.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_continents_asn.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_countries.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_countries_asn.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_regions.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_regions_asn.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_cities.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_cities_asn.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states_asn.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_global_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_continents.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_continents_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_countries.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_countries_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_regions.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_regions_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_cities.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_cities_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_us_states.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_us_states_asn.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_us_counties.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_us_counties_asn.sql
 
 echo "All views created successfully"

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -116,4 +116,19 @@ create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hou
 create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_uploads_after.sql
 create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_uploads_before.sql
 
+# stats-pipeline
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_global_asn.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_continents.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_continents_asn.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_countries.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_countries_asn.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_regions.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_regions_asn.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_cities.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_cities_asn.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_states_asn.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties.sql
+create_view ${DST_PROJECT} ${DST_PROJECT} ./statistics/v0_us_counties_asn.sql
+
 echo "All views created successfully"


### PR DESCRIPTION
The previous PRs related to adding views for stats-pipeline bigquery tables did not include the dataset name in the script that creates the views. This PR corrects that. This branch has built in cloud build successfully, with the expected result of new versioned views in `mlab-sandbox.statistics`

@stephen-soltesz PTAL?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/102)
<!-- Reviewable:end -->
