### PR TITLE
Use ndt5 legacy view

### DIFF
--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -12,7 +12,7 @@ WITH ndt5downloads AS (
   SELECT partition_date, ParseInfo, result.S2C,
   (result.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(result.S2C.EndTime, result.S2C.StartTime, MICROSECOND) AS connection_duration
-  FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt
+  FROM   `{{.ProjectID}}.ndt_raw.ndt5_legacy` -- TODO move to intermediate_ndt
   -- Limit to valid S2C results
   WHERE result.S2C IS NOT NULL
   AND result.S2C.UUID IS NOT NULL

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -12,7 +12,7 @@ WITH ndt5uploads AS (
   SELECT partition_date, ParseInfo, result.C2S,
   (result.C2S.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(result.C2S.EndTime, result.C2S.StartTime, MICROSECOND) AS connection_duration
-  FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt
+  FROM   `{{.ProjectID}}.ndt_raw.ndt5_legacy` -- TODO move to intermediate_ndt
   -- Limit to valid C2S results
   WHERE  result.C2S IS NOT NULL
   AND result.C2S.UUID NOT IN ( '', 'ERROR_DISCOVERING_UUID' )


### PR DESCRIPTION
This change updates the extended views for ndt5 to use the `ndt_raw.ndt5_legacy` view. This change will allow us to remove the `ndt.ndt5` v1 schema view in favor of the new deployment of the v2 ndt5 parser and v2 schemas.

Because the `ndt.ndt5` and `ndt_raw.ndt5_legacy` views are identical, no user-visible changes are expected.

Part of:
* https://github.com/m-lab/etl/issues/1050
* https://github.com/m-lab/etl/issues/1046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/113)
<!-- Reviewable:end -->
