### PR TITLE
Add "legacy" views for sidestream.web100 and utilization.switch

### DIFF
--- a/views/sidestream/web100_legacy.sql
+++ b/views/sidestream/web100_legacy.sql
@@ -1,0 +1,4 @@
+#standardSQL
+-- This is the sidestream root view that all other views in the sidestream dataset are derived from.
+SELECT CAST(_PARTITIONTIME AS DATE) AS partition_date, *
+FROM `{{.ProjectID}}.base_tables.sidestream`

--- a/views/utilization/switch_legacy.sql
+++ b/views/utilization/switch_legacy.sql
@@ -1,0 +1,4 @@
+#standardSQL
+-- This is the utilization root view of the switch dataset.
+SELECT CAST(_PARTITIONTIME AS DATE) AS partition_date, *
+FROM `{{.ProjectID}}.base_tables.switch`


### PR DESCRIPTION
This change adds two new views for legacy schemas `sidestream.web100_legacy` and `utilization.switch_legacy`.

This change allows us to migrate dependencies (e.g. prometheus-support) on the old names before deploying versions (i.e. `utilization.switch`) with an updated v2 schema.

Part of
* https://github.com/m-lab/etl/issues/1050 

FYI: @robertodauria re: switch.