### PR TITLE
Update all references to use legacy views where appropriate

### DIFF
--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -21,7 +21,7 @@ WITH ndt5downloads AS (
 
 tcpinfo AS (
   SELECT * EXCEPT (snapshots)
-  FROM `{{.ProjectID}}.ndt.tcpinfo` -- TODO move to intermediate_ndt
+  FROM `{{.ProjectID}}.ndt_raw.tcpinfo_legacy` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -20,7 +20,7 @@ WITH ndt5uploads AS (
 
 tcpinfo AS (
   SELECT * EXCEPT (snapshots)
-  FROM `{{.ProjectID}}.ndt.tcpinfo` -- TODO move to intermediate_ndt
+  FROM `{{.ProjectID}}.ndt_raw.tcpinfo_legacy` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (

--- a/views/ndt_intermediate/extended_web100_downloads.sql
+++ b/views/ndt_intermediate/extended_web100_downloads.sql
@@ -47,7 +47,7 @@ WITH PreCleanWeb100 AS (
       task_filename AS ArchiveURL,
       "web100" AS Filename
     ) AS Web100parser,
-  FROM `{{.ProjectID}}.ndt.web100` -- TODO move to intermediate_ndt
+  FROM `{{.ProjectID}}.ndt_raw.web100_legacy` -- TODO move to intermediate_ndt
   WHERE
     web100_log_entry.snap.Duration IS NOT NULL
     AND web100_log_entry.snap.State IS NOT NULL

--- a/views/ndt_intermediate/extended_web100_uploads.sql
+++ b/views/ndt_intermediate/extended_web100_uploads.sql
@@ -47,7 +47,7 @@ WITH PreCleanWeb100 AS (
       task_filename AS ArchiveURL,
       "web100" AS Filename
     ) AS Web100parser,
-  FROM `{{.ProjectID}}.ndt.web100` -- TODO move to intermediate_ndt
+  FROM `{{.ProjectID}}.ndt_raw.web100_legacy` -- TODO move to intermediate_ndt
   WHERE
     web100_log_entry.snap.Duration IS NOT NULL
     AND web100_log_entry.snap.State IS NOT NULL

--- a/views/website/entry07_platform_decile_downloads_dedup_daily_after.sql
+++ b/views/website/entry07_platform_decile_downloads_dedup_daily_after.sql
@@ -15,7 +15,7 @@ WITH raw_web100 AS (
       web100_log_entry.snap.SndLimTimeCwnd +
         web100_log_entry.snap.SndLimTimeSnd) / 1000000.0 AS duration
 
-FROM `{{.ProjectID}}.ndt.web100`
+FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
 WHERE
       partition_date BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")
@@ -53,7 +53,7 @@ WHERE
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.S2C.EndTime, result.S2C.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")

--- a/views/website/entry07_platform_decile_downloads_dedup_daily_before.sql
+++ b/views/website/entry07_platform_decile_downloads_dedup_daily_before.sql
@@ -15,7 +15,7 @@ WITH raw_web100 AS (
       web100_log_entry.snap.SndLimTimeCwnd +
         web100_log_entry.snap.SndLimTimeSnd) / 1000000.0 AS duration
 
-FROM `{{.ProjectID}}.ndt.web100`
+FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
 WHERE
       partition_date BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")
@@ -53,7 +53,7 @@ WHERE
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.S2C.EndTime, result.S2C.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")

--- a/views/website/entry07_platform_decile_uploads_dedup_daily_after.sql
+++ b/views/website/entry07_platform_decile_uploads_dedup_daily_after.sql
@@ -14,7 +14,7 @@ WITH raw_web100 AS (
         web100_log_entry.snap.Duration-2000000,
         web100_log_entry.snap.Duration)) / 1000000.0 AS duration
 
-  FROM `{{.ProjectID}}.ndt.web100`
+  FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
   WHERE
       partition_date BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")
@@ -50,7 +50,7 @@ WITH raw_web100 AS (
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.C2S.EndTime, result.C2S.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")

--- a/views/website/entry07_platform_decile_uploads_dedup_daily_before.sql
+++ b/views/website/entry07_platform_decile_uploads_dedup_daily_before.sql
@@ -14,7 +14,7 @@ WITH raw_web100 AS (
         web100_log_entry.snap.Duration-2000000,
         web100_log_entry.snap.Duration)) / 1000000.0 AS duration
 
-  FROM `{{.ProjectID}}.ndt.web100`
+  FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
   WHERE
 
@@ -51,7 +51,7 @@ WITH raw_web100 AS (
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.C2S.EndTime, result.C2S.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")

--- a/views/website/entry07_platform_hourly_downloads_after.sql
+++ b/views/website/entry07_platform_hourly_downloads_after.sql
@@ -17,7 +17,7 @@ WITH raw_web100 AS (
       web100_log_entry.snap.SndLimTimeCwnd +
         web100_log_entry.snap.SndLimTimeSnd) / 1000000.0 AS duration
 
-FROM `{{.ProjectID}}.ndt.web100`
+FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
 WHERE
       partition_date BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")
@@ -54,7 +54,7 @@ WHERE
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.S2C.EndTime, result.S2C.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")

--- a/views/website/entry07_platform_hourly_downloads_before.sql
+++ b/views/website/entry07_platform_hourly_downloads_before.sql
@@ -17,7 +17,7 @@ WITH raw_web100 AS (
       web100_log_entry.snap.SndLimTimeCwnd +
         web100_log_entry.snap.SndLimTimeSnd) / 1000000.0 AS duration
 
-FROM `{{.ProjectID}}.ndt.web100`
+FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
 WHERE
       partition_date BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")
@@ -54,7 +54,7 @@ WHERE
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.S2C.EndTime, result.S2C.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")

--- a/views/website/entry07_platform_hourly_uploads_after.sql
+++ b/views/website/entry07_platform_hourly_uploads_after.sql
@@ -15,7 +15,7 @@ WITH raw_web100 AS (
       cast(connection_spec.tls AS string)) AS protocol,
     (web100_log_entry.snap.Duration) / 1000000.0 AS duration
 
-  FROM `{{.ProjectID}}.ndt.web100`
+  FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
   WHERE
       partition_date BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")
@@ -51,7 +51,7 @@ raw_ndt5 AS (
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.C2S.EndTime, result.C2S.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-19") AND DATE("2019-07-25")

--- a/views/website/entry07_platform_hourly_uploads_before.sql
+++ b/views/website/entry07_platform_hourly_uploads_before.sql
@@ -15,7 +15,7 @@ WITH raw_web100 AS (
       cast(connection_spec.tls AS string)) AS protocol,
     (web100_log_entry.snap.Duration) / 1000000.0 AS duration
 
-  FROM `{{.ProjectID}}.ndt.web100`
+  FROM `{{.ProjectID}}.ndt_raw.web100_legacy`
 
   WHERE
       partition_date BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")
@@ -51,7 +51,7 @@ raw_ndt5 AS (
     REPLACE(REGEXP_EXTRACT(ParseInfo.TaskFileName, "-(mlab[1-4]-[a-z]{3}[0-9]{2})-"), "-", ".") AS hostname,
     TIMESTAMP_DIFF(result.C2S.EndTime, result.C2S.StartTime, MILLISECOND)/1000 AS duration
 
-  FROM `{{.ProjectID}}.ndt.ndt5`
+  FROM `{{.ProjectID}}.ndt_raw.ndt5_legacy`
 
   WHERE
       DATE(result.StartTime) BETWEEN DATE("2019-07-10") AND DATE("2019-07-16")


### PR DESCRIPTION
This change updates all queries that reference an undecorated v1 schema view to use the equivalent view decorated with a "legacy" suffix. This change will allows us to eventually safely remove the undecorated v1 schema views after updating other dependencies on the old names (e.g. prometheus-support).

Part of:
* https://github.com/m-lab/etl/issues/1050