### PR TITLE
Create legacy views for switch and sidestream

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -105,10 +105,10 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper1_hopannotation1.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} aggregate ./aggregate/traceroute.sql
 
 # global web100 sidestream (legacy parser)
-create_view ${SRC_PROJECT} ${DST_PROJECT} sidestream ./sidestream/web100.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} sidestream ./sidestream/web100_legacy.sql
 
 # switch telemetry (legacy parser)
-create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch_legacy.sql
 
 # website examples
 create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_decile_downloads_dedup_daily_after.sql


### PR DESCRIPTION
This change adds steps to create views for the v1 legacy sidestream and switch schemas. This change creates:

* `sidestream.web100_legacy`
* `utiliztion.switch_legacy`

This change removes the undecorated legacy name deployment (`web100` and `switch`) because the views will remain present until we manually remove it during future deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/116)
<!-- Reviewable:end -->
