### PR TITLE
Explicit NULL check for ndt5 Error field

### DIFF
--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -10,7 +10,7 @@
 
 WITH ndt5downloads AS (
   SELECT date, parser, raw.S2C, client, server,
-  (raw.S2C.Error != "") AS IsErrored,
+  (raw.S2C.Error IS NOT NULL AND raw.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(raw.S2C.EndTime, raw.S2C.StartTime, MICROSECOND) AS connection_duration
   FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt
   -- Limit to valid S2C results

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -10,7 +10,7 @@
 
 WITH ndt5uploads AS (
   SELECT date, parser, raw.C2S, client, server,
-  (raw.C2S.Error != "") AS IsErrored,
+  (raw.C2S.Error IS NOT NULL AND raw.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(raw.C2S.EndTime, raw.C2S.StartTime, MICROSECOND) AS connection_duration
   FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt
   -- Limit to valid C2S results


### PR DESCRIPTION
This change adds an explicit check for whether `raw.S2C.Error` and `raw.C2S.Error` are NULL when evaluating `IsErrored`. Previously, this field was either an empty string or an error message. Now, in the v2 parser, this value can be NULL. The result is that a null value evaluates as a null value (not a bool). And, when a "null" `IsErrored` is used later in `IsValidBest`, it too is NULL.

The reason for this change is due to how the v1 and v2 parsers operate and the field annotation [`json:",omitempty"`](https://github.com/m-lab/ndt-server/blob/3d30b2a84bc2f3251d8a72b68259de3d309f9a78/ndt5/s2c/s2c.go#L45). The v1 parser would using BQ insert using the Go struct, which preserved the default empty value. The v2 parser first writes the result to JSON before loading into BQ. The JSON translation omits the "empty" `Error` values, which BQ loads as NULL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/124)
<!-- Reviewable:end -->
