### PR TITLE
Mask Region field for Geo2 annotations for ndt5 and web100

### DIFF
--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -102,7 +102,26 @@ NDT5DownloadModels AS (
     STRUCT (
       S2C.ClientIP AS IP,
       S2C.ClientPort AS Port,
-      client.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        client.Geo.ContinentCode,
+        client.Geo.CountryCode,
+        client.Geo.CountryCode3,
+        client.Geo.CountryName,
+        "", -- mask out region.
+        client.Geo.Subdivision1ISOCode,
+        client.Geo.Subdivision1Name,
+        client.Geo.Subdivision2ISOCode,
+        client.Geo.Subdivision2Name,
+        client.Geo.MetroCode,
+        client.Geo.City,
+        client.Geo.AreaCode,
+        client.Geo.PostalCode,
+        client.Geo.Latitude,
+        client.Geo.Longitude,
+        client.Geo.AccuracyRadiusKm,
+        client.Geo.Missing
+      ) AS Geo,
       client.Network
     ) AS client,
     STRUCT (
@@ -110,7 +129,26 @@ NDT5DownloadModels AS (
       S2C.ServerPort AS Port,
       server.Site,
       server.Machine,
-      server.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        server.Geo.ContinentCode,
+        server.Geo.CountryCode,
+        server.Geo.CountryCode3,
+        server.Geo.CountryName,
+        "", -- mask out region.
+        server.Geo.Subdivision1ISOCode,
+        server.Geo.Subdivision1Name,
+        server.Geo.Subdivision2ISOCode,
+        server.Geo.Subdivision2Name,
+        server.Geo.MetroCode,
+        server.Geo.City,
+        server.Geo.AreaCode,
+        server.Geo.PostalCode,
+        server.Geo.Latitude,
+        server.Geo.Longitude,
+        server.Geo.AccuracyRadiusKm,
+        server.Geo.Missing
+      ) AS Geo,
       server.Network
     ) AS server,
     PreCleanNDT5 AS _internal202201  -- Not stable and subject to breaking changes

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -95,7 +95,26 @@ NDT5UploadModels AS (
     STRUCT (
       C2S.ClientIP AS IP,
       C2S.ClientPort AS Port,
-      client.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        client.Geo.ContinentCode,
+        client.Geo.CountryCode,
+        client.Geo.CountryCode3,
+        client.Geo.CountryName,
+        "", -- mask out region.
+        client.Geo.Subdivision1ISOCode,
+        client.Geo.Subdivision1Name,
+        client.Geo.Subdivision2ISOCode,
+        client.Geo.Subdivision2Name,
+        client.Geo.MetroCode,
+        client.Geo.City,
+        client.Geo.AreaCode,
+        client.Geo.PostalCode,
+        client.Geo.Latitude,
+        client.Geo.Longitude,
+        client.Geo.AccuracyRadiusKm,
+        client.Geo.Missing
+      ) AS Geo,
       client.Network
     ) AS client,
     STRUCT (
@@ -103,7 +122,26 @@ NDT5UploadModels AS (
       C2S.ServerPort AS Port,
       server.Site,
       server.Machine,
-      server.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        server.Geo.ContinentCode,
+        server.Geo.CountryCode,
+        server.Geo.CountryCode3,
+        server.Geo.CountryName,
+        "", -- mask out region.
+        server.Geo.Subdivision1ISOCode,
+        server.Geo.Subdivision1Name,
+        server.Geo.Subdivision2ISOCode,
+        server.Geo.Subdivision2Name,
+        server.Geo.MetroCode,
+        server.Geo.City,
+        server.Geo.AreaCode,
+        server.Geo.PostalCode,
+        server.Geo.Latitude,
+        server.Geo.Longitude,
+        server.Geo.AccuracyRadiusKm,
+        server.Geo.Missing
+      ) AS Geo,
       server.Network
     ) AS server,
     PreCleanNDT5 AS _internal202201  -- Not stable and subject to breaking changes

--- a/views/ndt_intermediate/extended_web100_downloads.sql
+++ b/views/ndt_intermediate/extended_web100_downloads.sql
@@ -91,7 +91,26 @@ Web100DownloadModels AS (
     STRUCT (
       web100_log_entry.connection_spec.remote_ip AS IP,
       web100_log_entry.connection_spec.remote_port AS Port,
-      connection_spec.ClientX.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        connection_spec.ClientX.Geo.ContinentCode,
+        connection_spec.ClientX.Geo.CountryCode,
+        connection_spec.ClientX.Geo.CountryCode3,
+        connection_spec.ClientX.Geo.CountryName,
+        "", -- mask out region.
+        connection_spec.ClientX.Geo.Subdivision1ISOCode,
+        connection_spec.ClientX.Geo.Subdivision1Name,
+        connection_spec.ClientX.Geo.Subdivision2ISOCode,
+        connection_spec.ClientX.Geo.Subdivision2Name,
+        connection_spec.ClientX.Geo.MetroCode,
+        connection_spec.ClientX.Geo.City,
+        connection_spec.ClientX.Geo.AreaCode,
+        connection_spec.ClientX.Geo.PostalCode,
+        connection_spec.ClientX.Geo.Latitude,
+        connection_spec.ClientX.Geo.Longitude,
+        connection_spec.ClientX.Geo.AccuracyRadiusKm,
+        connection_spec.ClientX.Geo.Missing
+      ) AS Geo,
       connection_spec.ClientX.Network
     ) AS client,
     STRUCT (
@@ -99,7 +118,26 @@ Web100DownloadModels AS (
       web100_log_entry.connection_spec.local_port AS Port,
       connection_spec.ServerX.Site,
       connection_spec.ServerX.Machine,
-      connection_spec.ServerX.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        connection_spec.ServerX.Geo.ContinentCode,
+        connection_spec.ServerX.Geo.CountryCode,
+        connection_spec.ServerX.Geo.CountryCode3,
+        connection_spec.ServerX.Geo.CountryName,
+        "", -- mask out region.
+        connection_spec.ServerX.Geo.Subdivision1ISOCode,
+        connection_spec.ServerX.Geo.Subdivision1Name,
+        connection_spec.ServerX.Geo.Subdivision2ISOCode,
+        connection_spec.ServerX.Geo.Subdivision2Name,
+        connection_spec.ServerX.Geo.MetroCode,
+        connection_spec.ServerX.Geo.City,
+        connection_spec.ServerX.Geo.AreaCode,
+        connection_spec.ServerX.Geo.PostalCode,
+        connection_spec.ServerX.Geo.Latitude,
+        connection_spec.ServerX.Geo.Longitude,
+        connection_spec.ServerX.Geo.AccuracyRadiusKm,
+        connection_spec.ServerX.Geo.Missing
+      ) AS Geo,
       connection_spec.ServerX.Network
     ) AS server,
     PreCleanWeb100 AS _internal202010  -- Not stable and subject to breaking changes

--- a/views/ndt_intermediate/extended_web100_uploads.sql
+++ b/views/ndt_intermediate/extended_web100_uploads.sql
@@ -89,7 +89,26 @@ Web100UploadModels AS (
     STRUCT (
       web100_log_entry.connection_spec.remote_ip AS IP,
       web100_log_entry.connection_spec.remote_port AS Port,
-      connection_spec.ClientX.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        connection_spec.ClientX.Geo.ContinentCode,
+        connection_spec.ClientX.Geo.CountryCode,
+        connection_spec.ClientX.Geo.CountryCode3,
+        connection_spec.ClientX.Geo.CountryName,
+        "", -- mask out region.
+        connection_spec.ClientX.Geo.Subdivision1ISOCode,
+        connection_spec.ClientX.Geo.Subdivision1Name,
+        connection_spec.ClientX.Geo.Subdivision2ISOCode,
+        connection_spec.ClientX.Geo.Subdivision2Name,
+        connection_spec.ClientX.Geo.MetroCode,
+        connection_spec.ClientX.Geo.City,
+        connection_spec.ClientX.Geo.AreaCode,
+        connection_spec.ClientX.Geo.PostalCode,
+        connection_spec.ClientX.Geo.Latitude,
+        connection_spec.ClientX.Geo.Longitude,
+        connection_spec.ClientX.Geo.AccuracyRadiusKm,
+        connection_spec.ClientX.Geo.Missing
+      ) AS Geo,
       connection_spec.ClientX.Network
     ) AS client,
     STRUCT (
@@ -97,7 +116,26 @@ Web100UploadModels AS (
       web100_log_entry.connection_spec.local_port AS Port,
       connection_spec.ServerX.Site,
       connection_spec.ServerX.Machine,
-      connection_spec.ServerX.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        connection_spec.ServerX.Geo.ContinentCode,
+        connection_spec.ServerX.Geo.CountryCode,
+        connection_spec.ServerX.Geo.CountryCode3,
+        connection_spec.ServerX.Geo.CountryName,
+        "", -- mask out region.
+        connection_spec.ServerX.Geo.Subdivision1ISOCode,
+        connection_spec.ServerX.Geo.Subdivision1Name,
+        connection_spec.ServerX.Geo.Subdivision2ISOCode,
+        connection_spec.ServerX.Geo.Subdivision2Name,
+        connection_spec.ServerX.Geo.MetroCode,
+        connection_spec.ServerX.Geo.City,
+        connection_spec.ServerX.Geo.AreaCode,
+        connection_spec.ServerX.Geo.PostalCode,
+        connection_spec.ServerX.Geo.Latitude,
+        connection_spec.ServerX.Geo.Longitude,
+        connection_spec.ServerX.Geo.AccuracyRadiusKm,
+        connection_spec.ServerX.Geo.Missing
+      ) AS Geo,
       connection_spec.ServerX.Network
     ) AS server,
     PreCleanWeb100 AS _internal202010  -- Not stable and subject to breaking changes


### PR DESCRIPTION
This change works around an artifact of the annotation-service [reusing the `Region` field][1] in Geo2 annotations by masking the Region field in the extended views for web100 and ndt5. See: https://github.com/m-lab/etl/issues/1069

This change helps make the migration to the Geo2 fields complete for all datatypes and in a single step. Because the Region field is from the older Geo1 format, the Region field was never set for native annotations collected by the uuid-annotator on the platform.

[1]: https://github.com/m-lab/annotation-service/blob/bb4c0204a671375cdbae35c6ade3199569e2c375/geolite2v2/geo-ip-loc-loader.go#L121-L124

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/125)
<!-- Reviewable:end -->
