### PR TITLE
Mask Region field for Geo2 annotations for ndt7 extended views

### DIFF
--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -94,7 +94,26 @@ NDT7DownloadModels AS (
     STRUCT (
       raw.ClientIP AS IP,
       raw.ClientPort AS Port,
-      client.Geo, -- The entire new geo struct
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        client.Geo.ContinentCode,
+        client.Geo.CountryCode,
+        client.Geo.CountryCode3,
+        client.Geo.CountryName,
+        "", -- mask out region.
+        client.Geo.Subdivision1ISOCode,
+        client.Geo.Subdivision1Name,
+        client.Geo.Subdivision2ISOCode,
+        client.Geo.Subdivision2Name,
+        client.Geo.MetroCode,
+        client.Geo.City,
+        client.Geo.AreaCode,
+        client.Geo.PostalCode,
+        client.Geo.Latitude,
+        client.Geo.Longitude,
+        client.Geo.AccuracyRadiusKm,
+        client.Geo.Missing
+      ) AS Geo,
       client.Network
     ) AS client,
     STRUCT (

--- a/views/ndt_intermediate/extended_ndt7_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt7_uploads.sql
@@ -89,7 +89,26 @@ NDT7UploadModels AS (
     STRUCT (
       raw.ClientIP AS IP,
       raw.ClientPort AS Port,
-      client.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        client.Geo.ContinentCode,
+        client.Geo.CountryCode,
+        client.Geo.CountryCode3,
+        client.Geo.CountryName,
+        "", -- mask out region.
+        client.Geo.Subdivision1ISOCode,
+        client.Geo.Subdivision1Name,
+        client.Geo.Subdivision2ISOCode,
+        client.Geo.Subdivision2Name,
+        client.Geo.MetroCode,
+        client.Geo.City,
+        client.Geo.AreaCode,
+        client.Geo.PostalCode,
+        client.Geo.Latitude,
+        client.Geo.Longitude,
+        client.Geo.AccuracyRadiusKm,
+        client.Geo.Missing
+      ) AS Geo,
       client.Network
     ) AS client,
     STRUCT (
@@ -97,7 +116,26 @@ NDT7UploadModels AS (
       raw.ServerPort AS Port,
       server.Site, -- e.g. lga02
       server.Machine, -- e.g. mlab1
-      server.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        server.Geo.ContinentCode,
+        server.Geo.CountryCode,
+        server.Geo.CountryCode3,
+        server.Geo.CountryName,
+        "", -- mask out region.
+        server.Geo.Subdivision1ISOCode,
+        server.Geo.Subdivision1Name,
+        server.Geo.Subdivision2ISOCode,
+        server.Geo.Subdivision2Name,
+        server.Geo.MetroCode,
+        server.Geo.City,
+        server.Geo.AreaCode,
+        server.Geo.PostalCode,
+        server.Geo.Latitude,
+        server.Geo.Longitude,
+        server.Geo.AccuracyRadiusKm,
+        server.Geo.Missing
+      ) AS Geo,
       server.Network
     ) AS server,
     PreCleanNDT7 AS _internal202010  -- Not stable and subject to breaking changes


### PR DESCRIPTION
A continuation of https://github.com/m-lab/etl-schema/pull/125 since the annotation-service [reused the `Region` field][1] in Geo2 annotations, a handful of synthetic ndt7 annotations between Feb and Mar 2020 include Region fields. These changes can be removed once https://github.com/m-lab/etl/issues/1069 is resolved.

[1]: https://github.com/m-lab/annotation-service/blob/bb4c0204a671375cdbae35c6ade3199569e2c375/geolite2v2/geo-ip-loc-loader.go#L121-L124

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/126)
<!-- Reviewable:end -->
