### PR TITLE
Name empty Region field

### DIFF
--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -100,7 +100,7 @@ NDT7DownloadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        "", -- mask out region.
+        "" as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -121,7 +121,26 @@ NDT7DownloadModels AS (
       raw.ServerPort AS Port,
       server.Site, -- e.g. lga02
       server.Machine, -- e.g. mlab1
-      server.Geo,
+      -- TODO(https://github.com/m-lab/etl/issues/1069): eliminate region mask once parser does this.
+      STRUCT(
+        server.Geo.ContinentCode,
+        server.Geo.CountryCode,
+        server.Geo.CountryCode3,
+        server.Geo.CountryName,
+        "" as Region, -- mask out region.
+        server.Geo.Subdivision1ISOCode,
+        server.Geo.Subdivision1Name,
+        server.Geo.Subdivision2ISOCode,
+        server.Geo.Subdivision2Name,
+        server.Geo.MetroCode,
+        server.Geo.City,
+        server.Geo.AreaCode,
+        server.Geo.PostalCode,
+        server.Geo.Latitude,
+        server.Geo.Longitude,
+        server.Geo.AccuracyRadiusKm,
+        server.Geo.Missing
+      ) AS Geo,
       server.Network
     ) AS server,
     PreCleanNDT7 AS _internal202010  -- Not stable and subject to breaking changes

--- a/views/ndt_intermediate/extended_ndt7_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt7_uploads.sql
@@ -95,7 +95,7 @@ NDT7UploadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        "", -- mask out region.
+        "" as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -122,7 +122,7 @@ NDT7UploadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        "", -- mask out region.
+        "" as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,


### PR DESCRIPTION
This change names the empty `Region` field for ndt7 client and server Geo structures. This name is not necessary for other data types because the name is inherited from the first structure in a `UNION ALL`. But, because ndt7 is the first it must name the field.

This change also includes an intended, but accidentally unsaved change to the download `server.Geo` struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/127)
<!-- Reviewable:end -->
