### PR TITLE
Make Region NULL as it is in the annotation table

### DIFF
--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -108,7 +108,7 @@ NDT5DownloadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -135,7 +135,7 @@ NDT5DownloadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -101,7 +101,7 @@ NDT5UploadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -128,7 +128,7 @@ NDT5UploadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -100,7 +100,7 @@ NDT7DownloadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        "" as Region, -- mask out region.
+        NULL as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -127,7 +127,7 @@ NDT7DownloadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        "" as Region, -- mask out region.
+        NULL as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_ndt7_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt7_uploads.sql
@@ -95,7 +95,7 @@ NDT7UploadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        "" as Region, -- mask out region.
+        NULL as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -122,7 +122,7 @@ NDT7UploadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        "" as Region, -- mask out region.
+        NULL as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_web100_downloads.sql
+++ b/views/ndt_intermediate/extended_web100_downloads.sql
@@ -97,7 +97,7 @@ Web100DownloadModels AS (
         connection_spec.ClientX.Geo.CountryCode,
         connection_spec.ClientX.Geo.CountryCode3,
         connection_spec.ClientX.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         connection_spec.ClientX.Geo.Subdivision1ISOCode,
         connection_spec.ClientX.Geo.Subdivision1Name,
         connection_spec.ClientX.Geo.Subdivision2ISOCode,
@@ -124,7 +124,7 @@ Web100DownloadModels AS (
         connection_spec.ServerX.Geo.CountryCode,
         connection_spec.ServerX.Geo.CountryCode3,
         connection_spec.ServerX.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         connection_spec.ServerX.Geo.Subdivision1ISOCode,
         connection_spec.ServerX.Geo.Subdivision1Name,
         connection_spec.ServerX.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_web100_uploads.sql
+++ b/views/ndt_intermediate/extended_web100_uploads.sql
@@ -95,7 +95,7 @@ Web100UploadModels AS (
         connection_spec.ClientX.Geo.CountryCode,
         connection_spec.ClientX.Geo.CountryCode3,
         connection_spec.ClientX.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         connection_spec.ClientX.Geo.Subdivision1ISOCode,
         connection_spec.ClientX.Geo.Subdivision1Name,
         connection_spec.ClientX.Geo.Subdivision2ISOCode,
@@ -122,7 +122,7 @@ Web100UploadModels AS (
         connection_spec.ServerX.Geo.CountryCode,
         connection_spec.ServerX.Geo.CountryCode3,
         connection_spec.ServerX.Geo.CountryName,
-        "", -- mask out region.
+        NULL as Region, -- mask out region.
         connection_spec.ServerX.Geo.Subdivision1ISOCode,
         connection_spec.ServerX.Geo.Subdivision1Name,
         connection_spec.ServerX.Geo.Subdivision2ISOCode,


### PR DESCRIPTION
While verifying the values produced by the annotation parser & in BQ vs the values produced by the unpublished unified views, I discovered that the annotation structure also uses `omitempty` tags and unspecified values should be `NULL` not the empty string.

This is part of:
* https://github.com/m-lab/etl/issues/1069

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/128)
<!-- Reviewable:end -->
