### PR TITLE
Automate creation of pass-through views for ndt5, ndt7, tcpinfo, and scamper1

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -102,6 +102,17 @@ create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_20201026x.sq
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper1_hopannotation1.sql
 
+# Public pass-through views for joined tables.
+if [[ ${DST_PROJECT} = "measurement-lab" ]] ; then
+    # NOTE: these steps can only be applied in the public measurement-lab
+    # project because in other M-Lab projects, these targets are actual
+    # tables. Only in measurement-lab can we create these views.
+    create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt5.sql
+    create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7.sql
+    create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/tcpinfo.sql
+    create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper1.sql
+fi
+
 # traceroute (legacy parser)
 create_view ${SRC_PROJECT} ${DST_PROJECT} aggregate ./aggregate/traceroute.sql
 

--- a/views/ndt/ndt5.sql
+++ b/views/ndt/ndt5.sql
@@ -1,0 +1,5 @@
+--
+-- This view is a pass-through for annotated ndt5 data.  This materializes data
+-- from ndt_raw.ndt5 with ndt_raw.annotation into a single location.
+--
+SELECT * FROM `{{.ProjectID}}.ndt.ndt5`

--- a/views/ndt/ndt7.sql
+++ b/views/ndt/ndt7.sql
@@ -1,0 +1,5 @@
+--
+-- This view is a pass-through for annotated ndt7 data.  This materializes data
+-- from ndt_raw.ndt7 with ndt_raw.annotation into a single location.
+--
+SELECT * FROM `{{.ProjectID}}.ndt.ndt7`

--- a/views/ndt/scamper1.sql
+++ b/views/ndt/scamper1.sql
@@ -1,0 +1,8 @@
+--
+-- This view is a pass-through for annotated scamper1 data. This materializes
+-- data from ndt_raw.scamper1 with ndt_raw.annotation into a single location.
+--
+-- This table includes server and client annotations but not hop annotations. For
+-- recent hop annotations see: `ndt.scamper1_hopannotation1`.
+--
+SELECT * FROM `{{.ProjectID}}.ndt.scamper1`

--- a/views/ndt/tcpinfo.sql
+++ b/views/ndt/tcpinfo.sql
@@ -1,0 +1,5 @@
+--
+-- This view is a pass-through for annotated tcpinfo data.  This materializes data
+-- from ndt_raw.tcpinfo with ndt_raw.annotation into a single location.
+--
+SELECT * FROM `{{.ProjectID}}.ndt.tcpinfo`


### PR DESCRIPTION
As a result of the [Deploying ndt5 extended views][1] incident, we found that several pass-through views were either created manually or do not exist. This change adds all missing pass-through views with conditional deployment for the measurement-lab project only.

If this automation had been in place originally, the initial part of the incident where users experienced permission errors would not have occurred.

[1]: https://docs.google.com/document/d/15sCn4ZLNj8TEj2_Dlvszg89tYIZo9_rbHm_lHTRlIpw/edit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/131)
<!-- Reviewable:end -->
