### PR TITLE
Update unified views to use v2 tcpinfo tables

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -86,6 +86,7 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/ndt7.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/pcap.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/hopannotation1.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/scamper1.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/tcpinfo.sql
 
 # NDT extended (mixed parsers)
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt_intermediate ./ndt_intermediate/extended_ndt5_downloads.sql

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -20,13 +20,13 @@ WITH ndt5downloads AS (
 ),
 
 tcpinfo AS (
-  SELECT * FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
+  SELECT *, a.FinalSnapshot EXCEPT(a) FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (
   SELECT
     downloads.*,
-    tcpinfo.a.FinalSnapshot AS FinalSnapshot,
+    FinalSnapshot,
     -- Any loss implys a netowork bottleneck
     (FinalSnapshot.TCPInfo.TotalRetrans > 0) AS IsCongested,
     -- Final RTT sample twice the minimum and above 1 second means bloated

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -9,7 +9,7 @@
 --
 
 WITH ndt5downloads AS (
-  SELECT date, parser, raw.S2C, client, server,
+  SELECT id, date, parser, raw.S2C, client, server,
   (raw.S2C.Error IS NOT NULL AND raw.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(raw.S2C.EndTime, raw.S2C.StartTime, MICROSECOND) AS connection_duration
   FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -20,8 +20,7 @@ WITH ndt5downloads AS (
 ),
 
 tcpinfo AS (
-  SELECT * EXCEPT (snapshots)
-  FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
+  SELECT * FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -9,7 +9,7 @@
 --
 
 WITH ndt5downloads AS (
-  SELECT id, date, parser, raw.S2C, client, server,
+  SELECT id, date, parser, raw.S2C, client, server, a,
   (raw.S2C.Error IS NOT NULL AND raw.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(raw.S2C.EndTime, raw.S2C.StartTime, MICROSECOND) AS connection_duration
   FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -21,13 +21,13 @@ WITH ndt5downloads AS (
 
 tcpinfo AS (
   SELECT * EXCEPT (snapshots)
-  FROM `{{.ProjectID}}.ndt_raw.tcpinfo_legacy` -- TODO move to intermediate_ndt
+  FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (
   SELECT
     downloads.*,
-    tcpinfo.FinalSnapshot AS FinalSnapshot,
+    tcpinfo.a.FinalSnapshot AS FinalSnapshot,
     -- Any loss implys a netowork bottleneck
     (FinalSnapshot.TCPInfo.TotalRetrans > 0) AS IsCongested,
     -- Final RTT sample twice the minimum and above 1 second means bloated
@@ -51,28 +51,28 @@ PreCleanNDT5 AS (
                 16) = NET.IP_FROM_STRING("192.168.0.0"))
       OR REGEXP_EXTRACT(downloads.parser.ArchiveURL, '(mlab[1-4])-[a-z][a-z][a-z][0-9][0-9t]') = 'mlab4'
     ) AS IsOAM,  -- Data is not from valid clients
-    tcpinfo.ParseInfo AS TCPparser,
+    tcpinfo.parser AS TCPparser,
     downloads.parser AS NDT5parser,
   FROM
     -- Use a left join to allow NDT test without matching tcpinfo rows.
     ndt5downloads AS downloads
     LEFT JOIN tcpinfo
     ON
-      downloads.date = tcpinfo.partition_date AND -- This may exclude a few rows issue:#63
-      downloads.S2C.UUID = tcpinfo.UUID
+      downloads.date = tcpinfo.date AND -- This may exclude a few rows issue:#63
+      downloads.id = tcpinfo.id
 ),
 
 NDT5DownloadModels AS (
   SELECT
-    S2C.UUID AS id,
+    id,
     date,
     STRUCT (
       -- NDT unified fields: Upload/Download/RTT/Loss/CCAlg + Geo + ASN
-      S2C.UUID,
-      S2C.StartTime AS TestTime,
+      a.UUID,
+      a.TestTime,
       FinalSnapshot.CongestionAlgorithm AS CongestionControl,
-      S2C.MeanThroughputMbps AS MeanThroughputMbps,
-      S2C.MinRTT/1000000.0 AS MinRTT, -- units are ms
+      a.MeanThroughputMbps AS MeanThroughputMbps,
+      a.MinRTT, -- units are ms
       SAFE_DIVIDE(FinalSnapshot.TCPInfo.BytesRetrans, FinalSnapshot.TCPInfo.BytesSent) AS LossRate
     ) AS a,
     STRUCT (

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -20,7 +20,7 @@ WITH ndt5downloads AS (
 ),
 
 tcpinfo AS (
-  SELECT *, a.FinalSnapshot EXCEPT(a) FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
+  SELECT * EXCEPT(a), a.FinalSnapshot FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -19,8 +19,7 @@ WITH ndt5uploads AS (
 ),
 
 tcpinfo AS (
-  SELECT * EXCEPT (snapshots)
-  FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
+  SELECT * FROM `{{.ProjectID}}.ndt_raw.tcpinfo` -- TODO move to intermediate_ndt
 ),
 
 PreCleanNDT5 AS (

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -9,7 +9,7 @@
 --
 
 WITH ndt5uploads AS (
-  SELECT id, date, parser, raw.C2S, client, server,
+  SELECT id, date, parser, raw.C2S, client, server, a,
   (raw.C2S.Error IS NOT NULL AND raw.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(raw.C2S.EndTime, raw.C2S.StartTime, MICROSECOND) AS connection_duration
   FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -9,7 +9,7 @@
 --
 
 WITH ndt5uploads AS (
-  SELECT date, parser, raw.C2S, client, server,
+  SELECT id, date, parser, raw.C2S, client, server,
   (raw.C2S.Error IS NOT NULL AND raw.S2C.Error != "") AS IsErrored,
   TIMESTAMP_DIFF(raw.C2S.EndTime, raw.C2S.StartTime, MICROSECOND) AS connection_duration
   FROM   `{{.ProjectID}}.ndt.ndt5` -- TODO move to intermediate_ndt

--- a/views/ndt_raw/annotation.sql
+++ b/views/ndt_raw/annotation.sql
@@ -1,3 +1,3 @@
 -- This is the raw ndt annotations view.
 --
-SELECT * FROM `{{.ProjectID}}.raw_ndt.annotation` -- TODO Move to new location
+SELECT * FROM `{{.ProjectID}}.raw_ndt.annotation`

--- a/views/ndt_raw/ndt7.sql
+++ b/views/ndt_raw/ndt7.sql
@@ -1,3 +1,3 @@
 -- This is the raw ndt7 view.
 --
-SELECT * FROM `{{.ProjectID}}.raw_ndt.ndt7` -- TODO Move to new location
+SELECT * FROM `{{.ProjectID}}.raw_ndt.ndt7`

--- a/views/ndt_raw/tcpinfo.sql
+++ b/views/ndt_raw/tcpinfo.sql
@@ -1,0 +1,3 @@
+-- This is the raw tcpinfo view.
+--
+SELECT * FROM `{{.ProjectID}}.raw_ndt.tcpinfo`


### PR DESCRIPTION
This change updates the unified views to use the v2 tcpinfo tables. This change should complete the unified view migration to using tables processed exclusively by the v2 parser (ndt5, tcpinfo, ndt7) -- (with the exception of ndt.web100 which does not add new data).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/133)
<!-- Reviewable:end -->
