### PR TITLE
Add transformation of v1 ndt web100 table to a v2-ish web100_static table

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,7 @@ steps:
     - PROJECT_IN=mlab-sandbox,mlab-staging
   args:
     - /workspace/views/create_dataset_views.sh self $PROJECT_ID $PROJECT_ID
+    - /workspace/transform/create_static_tables.sh $PROJECT_ID
 
 # Deployments to oti and measurement-lab.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif
@@ -31,4 +32,5 @@ steps:
     - PROJECT_IN=mlab-oti
   args:
     - /workspace/views/create_dataset_views.sh self $PROJECT_ID $PROJECT_ID
+    - /workspace/transform/create_static_tables.sh $PROJECT_ID
     - /workspace/views/create_dataset_views.sh self $PROJECT_ID measurement-lab

--- a/transform/create_static_tables.sh
+++ b/transform/create_static_tables.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# create_static_tables.sh runs a given sql query that creates a target table. If
+# that table already exists, no action is taken.
+#
+# The target table name is taken from the `CREATE TABLE` directive in the given
+# query.
+#
+# Example usage:
+#
+#  ./create_static_table.sh mlab-sandbox
+
+set -eu
+USAGE="$0 <target-project>"
+PROJECT=${1:?Please provide target project: $USAGE}
+
+BASEDIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
+cd ${BASEDIR}
+
+function create_table() {
+    local query_file=${1:?Please provide query file}
+    local table=$( grep 'CREATE TABLE' $query_file | awk '{print $3}' )
+
+    if ! bq show $PROJECT:$table > /dev/null ; then
+      # Table does not exist yet.
+      bq query --project_id=$PROJECT --nouse_legacy_sql "$( cat $query_file )"
+      echo "Created table $PROJECT.$table successfully"
+    else
+      echo "Confirmed table $PROJECT.$table exists"
+    fi
+}
+
+create_table ./web100_static.sql

--- a/transform/create_static_tables.sh
+++ b/transform/create_static_tables.sh
@@ -21,13 +21,8 @@ function create_table() {
     local query_file=${1:?Please provide query file}
     local table=$( grep 'CREATE TABLE' $query_file | awk '{print $3}' )
 
-    if ! bq show $PROJECT:$table > /dev/null ; then
-      # Table does not exist yet.
-      bq query --project_id=$PROJECT --nouse_legacy_sql "$( cat $query_file )"
-      echo "Created table $PROJECT.$table successfully"
-    else
-      echo "Confirmed table $PROJECT.$table exists"
-    fi
+    bq query --project_id=$PROJECT --nouse_legacy_sql "$( cat $query_file )"
+    echo "Created table $PROJECT.$table successfully"
 }
 
 create_table ./web100_static.sql

--- a/transform/web100_static.sql
+++ b/transform/web100_static.sql
@@ -1,0 +1,78 @@
+#standardSQL
+-- Transform the v1 base_tables.ndt data into a static, v2-compatible schema.
+-- Like tables produced by the v2 data pipeline, this static transformation will
+-- create a table that is both date partitioned and requires a partition filter
+-- for queries.
+--
+-- Always create within local project.
+CREATE TABLE ndt.web100_static
+PARTITION BY date
+OPTIONS (
+  require_partition_filter=true
+)
+AS
+-- The schema should respect the standard top-level column name conventions:
+--   * id
+--   * date
+--   * parser
+--   * server
+--   * client
+--   * a
+--   * raw
+SELECT
+   id,
+   DATE(log_time) AS date,
+   STRUCT(
+     parser_version AS Version,
+     parse_time     AS Time,
+	  task_filename  AS ArchiveURL,
+	  test_id        AS Filename,
+	  0              AS Priority,
+	  ""             AS GitCommit
+   ) AS parser,
+   connection_spec.ServerX AS server,
+   connection_spec.ClientX AS client,
+   IF(connection_spec.data_direction = 1,
+     -- download.
+     STRUCT(
+        id AS UUID,
+        log_time AS TestTime,
+        "reno" AS CongestionControl,
+        SAFE_DIVIDE(web100_log_entry.snap.HCThruOctetsAcked * 8.0,
+           web100_log_entry.snap.SndLimTimeRwin +
+           web100_log_entry.snap.SndLimTimeCwnd +
+           web100_log_entry.snap.SndLimTimeSnd) AS MeanThroughputMbps,
+        web100_log_entry.snap.MinRTT * 1.0 AS MinRTT,
+        SAFE_DIVIDE(web100_log_entry.snap.SegsRetrans, web100_log_entry.snap.SegsOut) AS LossRate
+     ),
+     -- upload.
+     STRUCT(
+        id AS UUID,
+        log_time AS TestTime,
+        '' AS CongestionControl, -- https://github.com/m-lab/etl-schema/issues/95
+        SAFE_DIVIDE(web100_log_entry.snap.HCThruOctetsReceived * 8.0, web100_log_entry.snap.Duration) AS MeanThroughputMbps,
+        web100_log_entry.snap.MinRTT * 1.0 AS MinRTT,  -- Note: download side measurement (ms)
+        NULL AS LossRate -- Receiver can not measure loss
+   )) AS a,
+   STRUCT(
+       STRUCT(
+        connection_spec.client_af,
+        connection_spec.client_application,
+        connection_spec.client_browser,
+        connection_spec.client_hostname,
+        connection_spec.client_ip,
+        connection_spec.client_kernel_version,
+        connection_spec.client_os,
+        connection_spec.client_version,
+        connection_spec.data_direction,
+        connection_spec.server_af,
+        connection_spec.server_hostname,
+        connection_spec.server_ip,
+        connection_spec.server_kernel_version,
+        connection_spec.tls,
+        connection_spec.websockets
+       ) AS connection,
+       web100_log_entry AS web100
+   ) AS raw,
+FROM `mlab-oti.base_tables.ndt`
+WHERE _PARTITIONTIME = "2019-01-01"

--- a/transform/web100_static.sql
+++ b/transform/web100_static.sql
@@ -75,4 +75,3 @@ SELECT
        web100_log_entry AS web100
    ) AS raw,
 FROM `mlab-oti.base_tables.ndt`
-WHERE _PARTITIONTIME = "2019-01-01"

--- a/transform/web100_static.sql
+++ b/transform/web100_static.sql
@@ -5,7 +5,7 @@
 -- for queries.
 --
 -- Always create within local project.
-CREATE TABLE ndt.web100_static
+CREATE TABLE IF NOT EXISTS ndt.web100_static
 PARTITION BY date
 OPTIONS (
   require_partition_filter=true
@@ -30,8 +30,50 @@ SELECT
 	  0              AS Priority,
 	  ""             AS GitCommit
    ) AS parser,
-   connection_spec.ServerX AS server,
-   connection_spec.ClientX AS client,
+   STRUCT(
+      STRUCT(
+        connection_spec.ServerX.Geo.ContinentCode,
+        connection_spec.ServerX.Geo.CountryCode,
+        connection_spec.ServerX.Geo.CountryCode3,
+        connection_spec.ServerX.Geo.CountryName,
+        CAST(NULL AS STRING) AS Region, -- mask out region.
+        connection_spec.ServerX.Geo.Subdivision1ISOCode,
+        connection_spec.ServerX.Geo.Subdivision1Name,
+        connection_spec.ServerX.Geo.Subdivision2ISOCode,
+        connection_spec.ServerX.Geo.Subdivision2Name,
+        connection_spec.ServerX.Geo.MetroCode,
+        connection_spec.ServerX.Geo.City,
+        connection_spec.ServerX.Geo.AreaCode,
+        connection_spec.ServerX.Geo.PostalCode,
+        connection_spec.ServerX.Geo.Latitude,
+        connection_spec.ServerX.Geo.Longitude,
+        connection_spec.ServerX.Geo.AccuracyRadiusKm,
+        connection_spec.ServerX.Geo.Missing
+      ) AS Geo,
+      connection_spec.ServerX.Network
+   ) AS server,
+   STRUCT(
+      STRUCT(
+        connection_spec.ClientX.Geo.ContinentCode,
+        connection_spec.ClientX.Geo.CountryCode,
+        connection_spec.ClientX.Geo.CountryCode3,
+        connection_spec.ClientX.Geo.CountryName,
+        CAST(NULL AS STRING) AS Region, -- mask out region.
+        connection_spec.ClientX.Geo.Subdivision1ISOCode,
+        connection_spec.ClientX.Geo.Subdivision1Name,
+        connection_spec.ClientX.Geo.Subdivision2ISOCode,
+        connection_spec.ClientX.Geo.Subdivision2Name,
+        connection_spec.ClientX.Geo.MetroCode,
+        connection_spec.ClientX.Geo.City,
+        connection_spec.ClientX.Geo.AreaCode,
+        connection_spec.ClientX.Geo.PostalCode,
+        connection_spec.ClientX.Geo.Latitude,
+        connection_spec.ClientX.Geo.Longitude,
+        connection_spec.ClientX.Geo.AccuracyRadiusKm,
+        connection_spec.ClientX.Geo.Missing
+      ) AS Geo,
+      connection_spec.ClientX.Network
+    ) AS client,
    IF(connection_spec.data_direction = 1,
      -- download.
      STRUCT(


### PR DESCRIPTION
This change adds a transformation query to create a static table using v2 naming conventions from the v1 ndt web100 data.

This query will provide a "v2"-like table schema with date partitioning and required filter queries that will ease the migration to the v2 pipeline and help optimize the unified view queries.

This change also adds a small script to deploy this and possibly future queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/134)
<!-- Reviewable:end -->
