### PR TITLE
Preserve Region type

### DIFF
--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -107,7 +107,7 @@ NDT5DownloadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -134,7 +134,7 @@ NDT5DownloadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -100,7 +100,7 @@ NDT5UploadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -127,7 +127,7 @@ NDT5UploadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -100,7 +100,7 @@ NDT7DownloadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -127,7 +127,7 @@ NDT7DownloadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_ndt7_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt7_uploads.sql
@@ -95,7 +95,7 @@ NDT7UploadModels AS (
         client.Geo.CountryCode,
         client.Geo.CountryCode3,
         client.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         client.Geo.Subdivision1ISOCode,
         client.Geo.Subdivision1Name,
         client.Geo.Subdivision2ISOCode,
@@ -122,7 +122,7 @@ NDT7UploadModels AS (
         server.Geo.CountryCode,
         server.Geo.CountryCode3,
         server.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         server.Geo.Subdivision1ISOCode,
         server.Geo.Subdivision1Name,
         server.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_web100_downloads.sql
+++ b/views/ndt_intermediate/extended_web100_downloads.sql
@@ -97,7 +97,7 @@ Web100DownloadModels AS (
         connection_spec.ClientX.Geo.CountryCode,
         connection_spec.ClientX.Geo.CountryCode3,
         connection_spec.ClientX.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         connection_spec.ClientX.Geo.Subdivision1ISOCode,
         connection_spec.ClientX.Geo.Subdivision1Name,
         connection_spec.ClientX.Geo.Subdivision2ISOCode,
@@ -124,7 +124,7 @@ Web100DownloadModels AS (
         connection_spec.ServerX.Geo.CountryCode,
         connection_spec.ServerX.Geo.CountryCode3,
         connection_spec.ServerX.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         connection_spec.ServerX.Geo.Subdivision1ISOCode,
         connection_spec.ServerX.Geo.Subdivision1Name,
         connection_spec.ServerX.Geo.Subdivision2ISOCode,

--- a/views/ndt_intermediate/extended_web100_uploads.sql
+++ b/views/ndt_intermediate/extended_web100_uploads.sql
@@ -95,7 +95,7 @@ Web100UploadModels AS (
         connection_spec.ClientX.Geo.CountryCode,
         connection_spec.ClientX.Geo.CountryCode3,
         connection_spec.ClientX.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         connection_spec.ClientX.Geo.Subdivision1ISOCode,
         connection_spec.ClientX.Geo.Subdivision1Name,
         connection_spec.ClientX.Geo.Subdivision2ISOCode,
@@ -122,7 +122,7 @@ Web100UploadModels AS (
         connection_spec.ServerX.Geo.CountryCode,
         connection_spec.ServerX.Geo.CountryCode3,
         connection_spec.ServerX.Geo.CountryName,
-        NULL as Region, -- mask out region.
+        CAST(NULL as STRING) as Region, -- mask out region.
         connection_spec.ServerX.Geo.Subdivision1ISOCode,
         connection_spec.ServerX.Geo.Subdivision1Name,
         connection_spec.ServerX.Geo.Subdivision2ISOCode,


### PR DESCRIPTION
This change updates the logic that masks the `Region` field to preserve the type as `STRING`.

Previously, because NULL has no type, the schema is inferred as an `INTEGER` without explicit direction. This change updates the `Region` value to use `CAST(NULL as STRING)` to preserve the string type and the NULL value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/135)
<!-- Reviewable:end -->
