### PR TITLE
Complete server record

### DIFF
--- a/transform/web100_static.sql
+++ b/transform/web100_static.sql
@@ -31,6 +31,8 @@ SELECT
 	  ""             AS GitCommit
    ) AS parser,
    STRUCT(
+      connection_spec.ServerX.Site,
+      connection_spec.ServerX.Machine,
       STRUCT(
         connection_spec.ServerX.Geo.ContinentCode,
         connection_spec.ServerX.Geo.CountryCode,


### PR DESCRIPTION
The original PR did not include all server fields, specifically `server.Site` and `server.Machine`. This change includes them. This addition is necessary to update the existing and optimized unified views to use the web100_static table with date partitioning and required partition filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/136)
<!-- Reviewable:end -->
