### PR TITLE
Include _nofilter versions of ndt unified views

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -57,6 +57,7 @@ function create_view() {
   description+=$'\n'"On :"`date`
 
   # Strip filename down to view name.
+  # Note that _nofilter views are generated with .SQL~ suffix to prevent checkin 
   view="${template%%.sql}"
   view="${view%%.SQL~}"
   view="${view##*/}"

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -58,6 +58,7 @@ function create_view() {
 
   # Strip filename down to view name.
   view="${template%%.sql}"
+  view="${view%%.SQL~}"
   view="${view##*/}"
 
   echo "Creating "${dst_project}.${dataset}.${view}" using "${template}
@@ -111,8 +112,12 @@ create_view ${DST_PROJECT} ${DST_PROJECT} ndt_intermediate ./ndt_intermediate/ex
 # NDT Unified
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_downloads_20201026x.sql
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_downloads.sql
+# Patch to create unified_downloads_nofilter (removes 2 clauses)
+sed -e 's/EXCEPT.*//' -e 's/WHERE IsValidBest//' ./ndt/unified_downloads.sql > ./ndt/unified_downloads_nofilter.SQL~
+create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_downloads_nofilter.SQL~
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_20201026x.sql
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads.sql
+
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper1_hopannotation1.sql
 
 # traceroute.

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -117,7 +117,9 @@ sed -e 's/EXCEPT.*//' -e 's/WHERE IsValidBest//' ./ndt/unified_downloads.sql > .
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_downloads_nofilter.SQL~
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_20201026x.sql
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads.sql
-
+# Patch to create unified_uploads_nofilter (removes 2 clauses)
+sed -e 's/EXCEPT.*//' -e 's/WHERE IsValidBest//' ./ndt/unified_uploads.sql > ./ndt/unified_uploads_nofilter.SQL~
+create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_nofilter.SQL~
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper1_hopannotation1.sql
 
 # traceroute.


### PR DESCRIPTION
Construct _nofilter versions by patching the unified_download and unified_upload views.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/142)
<!-- Reviewable:end -->
