### PR TITLE
Add pass-through view for Cloudflare tables

### DIFF
--- a/views/README.md
+++ b/views/README.md
@@ -42,17 +42,22 @@ Management of these permissions remains manual.
 
 ### Deployment to measurement-lab
 
-The general public accesses all M-Lab data through views published in the
-`measurement-lab` GCP Project. Not all views in this project are visible to the
-public by default. To make a `measurement-lab` dataset and views visible to the
-public, we must assign the disuss@measurementlab.net user specific roles.
+Members of the [discuss@measurementlab.net][discuss] mailing list may query all
+M-Lab data BigQuery data free of charge.
+
+All M-Lab data is accessed through views published in the `measurement-lab` GCP
+Project. Not all views in this project are visible to the public by default. To
+make a `measurement-lab` dataset and views visible to the public, we must assign
+the disuss@measurementlab.net user specific roles.
+
+[discuss]: https://groups.google.com/a/measurementlab.net/g/discuss?pli=1
 
 * `public-bigquery-user-dataset-level`
 
-  This role provides discuss@ group users with access to specific datasets in
-  the measurement-lab project. By default datasets are not visible to discuss@
-  users. Apply this role to individual BQ datasets to make them publically
-  viewable.
+  This role provides discuss@measurementlab.net group users with access to
+  specific datasets in the measurement-lab project. By default datasets are not
+  visible to discuss@ users. Apply this role to individual BQ datasets to make
+  them publicly viewable.
 
     ```txt
     bigquery.datasets.get
@@ -73,11 +78,12 @@ public, we must assign the disuss@measurementlab.net user specific roles.
 
 * `public-bigquery-user-project-level`
 
-  This role provides discuss@ group users with access to tables and views,
-  ability to select measurement-lab project, create jobs within the web console
-  & SDK, to save personal queries, and to export data. This role is assigned to
-  the discuss@ user in the project IAM settings, and automatically inhereited by
-  all BigQuery tables (no production deployment step necessary).
+  This role provides discuss@measurementlab.net group users with access to
+  tables and views, ability to select measurement-lab project, create jobs
+  within the web console & SDK, to save personal queries, and to export data.
+  This role is assigned to the discuss@ user in the project IAM settings, and
+  automatically inhereited by all BigQuery tables (no production deployment step
+  necessary).
 
   Role permissions include:
 

--- a/views/README.md
+++ b/views/README.md
@@ -4,33 +4,18 @@ This directory contains subdirectories containing .sql files that are used
 to create corresponding views in different projects.
 
 For now, these views should be simple, referencing only a single other table
-or view, and the views should NOT be nested very deep - no more than 2 levels
-below the dataset's canonical view.
+or view.
 
 For example, the ndt subdirectory contains:
 
-*  web100.sql
+* ndt7.sql
 
-As well, the ndt subdirectory includes `referenced-by` subdirectories with view
-templates that reference the top-level web100 view. For example:
+This will result in creation, e.g. in mlab-sandbox, of:
 
-*  referenced-by/recommended.sql
-
-Further `referenced-by` subdirectories may reference the views one level above
-it. For example:
-
-*  referenced-by/referenced-by/downloads.sql
-*  referenced-by/referenced-by/uploads.sql
-
-This will result in creation, e.g. for mlab-sandbox, of:
-
-- mlab-sandbox:ndt.web100
-- mlab-sandbox:ndt.recommended  - referencing web100
-- mlab-sandbox:ndt.downloads - referencing only recommended
-- mlab-sandbox:ndt.uploads - referencing only recommended.
+* mlab-sandbox:ndt.ndt7
 
 Each .sql file may contain a Go text/template referencing fields of a
-bigquery.Table, e.g. `{{.ProjectID}}` which will be replaced with
+`bigquery.Table`, e.g. `{{.ProjectID}}` which will be replaced with
 the current project name.
 
 ## Creating Views
@@ -42,3 +27,66 @@ the current project name.
 # To update public accessible views.
 ./create_dataset_views.sh "self" mlab-oti measurement-lab
 ```
+
+## Cloud Build Permissions
+
+View deployment is typically managed by Cloud Build. When views in one project
+reference tables in a second project, the Cloud Build service account must have
+permission to:
+
+* create views in the first project
+* modify the target datasets of the second project (to add the first project to
+  "Authorized views" in the second)
+
+Management of these permissions remains manual.
+
+### Deployment to measurement-lab
+
+The general public accesses all M-Lab data through views published in the
+`measurement-lab` GCP Project. Not all views in this project are visible to the
+public by default. To make a `measurement-lab` dataset and views visible to the
+public, we must assign the disuss@measurementlab.net user specific roles.
+
+* `public-bigquery-user-dataset-level`
+
+  This role provides discuss@ group users with access to specific datasets in
+  the measurement-lab project. By default datasets are not visible to discuss@
+  users. Apply this role to individual BQ datasets to make them publically
+  viewable.
+
+    ```txt
+    bigquery.datasets.get
+    bigquery.datasets.getIamPolicy
+    bigquery.jobs.create
+    bigquery.jobs.list
+    bigquery.readsessions.create
+    bigquery.readsessions.getData
+    bigquery.readsessions.update
+    bigquery.savedqueries.get
+    bigquery.savedqueries.list
+    bigquery.tables.export
+    bigquery.tables.get
+    bigquery.tables.getData
+    bigquery.tables.list
+    resourcemanager.projects.get
+    ```
+
+* `public-bigquery-user-project-level`
+
+  This role provides discuss@ group users with access to tables and views,
+  ability to select measurement-lab project, create jobs within the web console
+  & SDK, to save personal queries, and to export data. This role is assigned to
+  the discuss@ user in the project IAM settings, and automatically inhereited by
+  all BigQuery tables (no production deployment step necessary).
+
+  Role permissions include:
+
+    ```txt
+    bigquery.jobs.create
+    bigquery.jobs.list
+    bigquery.savedqueries.get
+    bigquery.savedqueries.list
+    bigquery.tables.export
+    bigquery.tables.getData
+    resourcemanager.projects.get`
+    ```

--- a/views/cloudflare/speedtest_speed1.sql
+++ b/views/cloudflare/speedtest_speed1.sql
@@ -1,1 +1,2 @@
+-- Pass-through view to Cloudflare Speedtest dataset.
 SELECT * FROM `mlab-cloudflare.speedtest.speed1`

--- a/views/cloudflare/speedtest_speed1.sql
+++ b/views/cloudflare/speedtest_speed1.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-clouddflare.speedtest.speed1`
+SELECT * FROM `mlab-cloudflare.speedtest.speed1`

--- a/views/cloudflare/speedtest_speed1.sql
+++ b/views/cloudflare/speedtest_speed1.sql
@@ -1,0 +1,1 @@
+SELECT * FROM `mlab-clouddflare.speedtest.speed1`

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -136,7 +136,7 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch_legac
 create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch.sql
 
 # passthrough for mlab-cloudflare tables.
-create_view ${SRC_PROJECT} ${DST_PROJECT} cloudflare ./cloudflare/speed1.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} cloudflare ./cloudflare/speedtest_speed1.sql
 
 # stats-pipeline
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_global_asn.sql

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -135,16 +135,6 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch_legac
 # switch telemetry (v2 parser)
 create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch.sql
 
-# website examples
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_decile_downloads_dedup_daily_after.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_decile_downloads_dedup_daily_before.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_decile_uploads_dedup_daily_after.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_decile_uploads_dedup_daily_before.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_downloads_after.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_downloads_before.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_uploads_after.sql
-create_view ${DST_PROJECT} ${DST_PROJECT} website ./website/entry07_platform_hourly_uploads_before.sql
-
 # stats-pipeline
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_global_asn.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_continents.sql

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -135,6 +135,9 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch_legac
 # switch telemetry (v2 parser)
 create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch.sql
 
+# passthrough for mlab-cloudflare tables.
+create_view ${SRC_PROJECT} ${DST_PROJECT} cloudflare ./cloudflare/speed1.sql
+
 # stats-pipeline
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_global_asn.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_continents.sql


### PR DESCRIPTION
This change introduces a pass-through view for the Cloudflare speedtest data.

Deployment to `measurement-lab.cloudflare.speedtest_speed1` will additionally require adding explicit permission to the discuss@ measurementlab.net list to the `measurement-lab.cloudflare` dataset.

```
Role:  public-bigquery-user-dataset-level
Email: discuss@measurementlab.net
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/146)
<!-- Reviewable:end -->
