### PR TITLE
Add new ArchiveSize and FileSize fields

### DIFF
--- a/transform/web100.sql
+++ b/transform/web100.sql
@@ -28,7 +28,9 @@ SELECT
 	  task_filename  AS ArchiveURL,
 	  test_id        AS Filename,
 	  0              AS Priority,
-	  ""             AS GitCommit
+	  ""             AS GitCommit,
+	  0              AS ArchiveSize,
+	  0              AS FileSize
    ) AS parser,
    STRUCT(
       connection_spec.ServerX.Site,


### PR DESCRIPTION
This change adds the `ArchiveSize` and `FileSize` fields to the synthetic, standard-column definition of the static web100 transformation.

The standard column version of the web100 schema is not actively managed by the current etl parser schema. So, these fields cannot be added automatically, as they are for all other datatypes.

Unfortunately, the unified views use `UNION ALL` across the the ndt7, ndt5, and legacy web100 tables. When the web100 schema is different, it causes the `UNION ALL` to fail.

This change corrects the schema for web100, but it must be applied manually.