### PR TITLE
Add views for autoloaded datatypes

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -90,6 +90,12 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/hopannotation2.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/scamper1.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/tcpinfo.sql
 
+# MSAK raw.
+create_view ${SRC_PROJECT} ${DST_PROJECT} msak_raw ./msak_raw/ndt8.sql
+
+# HOST raw.
+create_view ${SRC_PROJECT} ${DST_PROJECT} host_raw ./host_raw/nodeinfo1.sql
+
 # WEHE
 create_view ${SRC_PROJECT} ${DST_PROJECT} wehe_raw ./wehe_raw/annotation2.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} wehe_raw ./wehe_raw/hopannotation2.sql

--- a/views/host_raw/nodeinfo1.sql
+++ b/views/host_raw/nodeinfo1.sql
@@ -1,0 +1,3 @@
+-- This is the raw nodeinfo view.
+--
+SELECT * FROM `{{.ProjectID}}.raw_host.nodeinfo1`

--- a/views/msak_raw/ndt8.sql
+++ b/views/msak_raw/ndt8.sql
@@ -1,0 +1,3 @@
+-- This is the raw msak view.
+--
+SELECT * FROM `{{.ProjectID}}.raw_msak.ndt8`


### PR DESCRIPTION
This PR adds views for the datatypes currently being autoloaded ([msak](https://pantheon.corp.google.com/bigquery?referrer=search&project=mlab-sandbox&ws=!1m5!1m4!4m3!1smlab-sandbox!2smsak_raw!3sndt8) and [nodeinfo](https://pantheon.corp.google.com/bigquery?referrer=search&project=mlab-sandbox&ws=!1m5!1m4!4m3!1smlab-sandbox!2shost_raw!3snodeinfo1)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/159)
<!-- Reviewable:end -->
