### PR TITLE
Update README.md for project level permissions

### DIFF
--- a/views/README.md
+++ b/views/README.md
@@ -94,5 +94,7 @@ the disuss@measurementlab.net user specific roles.
     bigquery.savedqueries.list
     bigquery.tables.export
     bigquery.tables.getData
-    resourcemanager.projects.get`
+    resourcemanager.projects.get
+    bigquery.readsessions.create
+    bigquery.readsessions.getData
     ```


### PR DESCRIPTION
Python colabs use a slightly differnet API to access BigQuery for some datasets. As a result, users would see a permission error from Colab even when the BigQuery web UI would succeed.

This change adds documentation of the two additional permissions needed at the project level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/170)
<!-- Reviewable:end -->
