### PR TITLE
fixing use of * operator to merge tables

### DIFF
--- a/views/statistics/v0_cities.sql
+++ b/views/statistics/v0_cities.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.cities_*`
+SELECT * FROM `mlab-oti.statistics.cities_2*`

--- a/views/statistics/v0_cities_asn.sql
+++ b/views/statistics/v0_cities_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.cities_asn_*`
+SELECT * FROM `mlab-oti.statistics.cities_asn_2*`

--- a/views/statistics/v0_continents.sql
+++ b/views/statistics/v0_continents.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.continents_*`
+SELECT * FROM `mlab-oti.statistics.continents_2*`

--- a/views/statistics/v0_continents_asn.sql
+++ b/views/statistics/v0_continents_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.continents_asn_*`
+SELECT * FROM `mlab-oti.statistics.continents_asn_2*`

--- a/views/statistics/v0_countries.sql
+++ b/views/statistics/v0_countries.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.countries_*`
+SELECT * FROM `mlab-oti.statistics.countries_2*`

--- a/views/statistics/v0_countries_asn.sql
+++ b/views/statistics/v0_countries_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.countries_asn_*`
+SELECT * FROM `mlab-oti.statistics.countries_asn_2*`

--- a/views/statistics/v0_global_asn.sql
+++ b/views/statistics/v0_global_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.global_asn_*`
+SELECT * FROM `mlab-oti.statistics.global_asn_2*`

--- a/views/statistics/v0_regions.sql
+++ b/views/statistics/v0_regions.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.regions_*`
+SELECT * FROM `mlab-oti.statistics.regions_2*`

--- a/views/statistics/v0_regions_asn.sql
+++ b/views/statistics/v0_regions_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.regions_asn_*`
+SELECT * FROM `mlab-oti.statistics.regions_asn_2*`

--- a/views/statistics/v0_us_counties.sql
+++ b/views/statistics/v0_us_counties.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.us_counties_*`
+SELECT * FROM `mlab-oti.statistics.us_counties_2*`

--- a/views/statistics/v0_us_counties_asn.sql
+++ b/views/statistics/v0_us_counties_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.us_counties_asn_*`
+SELECT * FROM `mlab-oti.statistics.us_counties_asn_2*`

--- a/views/statistics/v0_us_states.sql
+++ b/views/statistics/v0_us_states.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.us_states_*`
+SELECT * FROM `mlab-oti.statistics.us_states_2*`

--- a/views/statistics/v0_us_states_asn.sql
+++ b/views/statistics/v0_us_states_asn.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `mlab-oti.statistics.us_states_asn_*`
+SELECT * FROM `mlab-oti.statistics.us_states_asn_2*`


### PR DESCRIPTION
Added "2" to the table string to prevent merging of both geo and asn tables e.g. `mlab-oti.statistics.countries` vs `mlab-oti.statistics.countries_asn`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/172)
<!-- Reviewable:end -->
