### PR TITLE
Add create_view for latency1 datatype

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -92,6 +92,7 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} ndt_raw ./ndt_raw/tcpinfo.sql
 
 # MSAK raw.
 create_view ${SRC_PROJECT} ${DST_PROJECT} msak_raw ./msak_raw/throughput1.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} msak_raw ./msak_raw/latency1.sql
 
 # HOST raw.
 create_view ${SRC_PROJECT} ${DST_PROJECT} host_raw ./host_raw/nodeinfo1.sql


### PR DESCRIPTION
This passthrough view query had been created but the corresponding `create_view`  in `create_dataset_views.sh` was missing.

Closes #173

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/174)
<!-- Reviewable:end -->
