### PR TITLE
Add annotated throughput1 view

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -171,6 +171,9 @@ create_view ${SRC_PROJECT} ${DST_PROJECT} utilization ./utilization/switch.sql
 # passthrough for mlab-cloudflare tables.
 create_view ${SRC_PROJECT} ${DST_PROJECT} cloudflare ./cloudflare/speedtest_speed1.sql
 
+# MSAK
+create_view ${SRC_PROJECT} ${DST_PROJECT} msak ./msak/throughput1.sql
+
 # stats-pipeline
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_global_asn.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} statistics ./statistics/v0_continents.sql

--- a/views/msak/throughput1.sql
+++ b/views/msak/throughput1.sql
@@ -1,0 +1,20 @@
+--
+-- This view contains annotated throughput1 data.  This materializes data
+-- from msak_raw.throughput1 with msak_raw.annotation2 into a single location.
+--
+SELECT
+    raw.UUID as id,
+    t1.date as date,
+    STRUCT(raw.StartTime as StartTime,
+        raw.EndTime as EndTime,
+        raw.MeasurementID as MeasurementID,
+        raw.UUID as UUID,
+        raw.Direction as Direction,
+        raw.CCAlgorithm as CongestionControl) as a,
+    archiver,
+    server,
+    client,
+    raw
+FROM
+    `{{.ProjectID}}.msak_raw.throughput1` t1
+    JOIN `{{.ProjectID}}.msak_raw.annotation2` t2 ON t1.raw.UUID = t2.id


### PR DESCRIPTION
This PR adds a view under the `msak` namespace that joins the `throughput1` and `annotation2` tables to add server/client annotations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/176)
<!-- Reviewable:end -->
