### PR TITLE
Remove time filter for early-exit tests

### DIFF
--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -111,7 +111,7 @@ UnifiedDownloadSchema AS (
       _IsRFC1918,            -- Not a real client (deprecate?)
       False AS IsPlatformAnomaly, -- FUTURE, No switch discards, etc
       (FinalSnapshot.TCPInfo.BytesAcked < 8192) AS IsSmall, -- not enough data
-      (test_duration < 9000.0 AND !IsEarlyExit) AS IsShort,   -- Did not run for enough time (does not apply to early-exit tests)
+      (test_duration < 9000.0 AND IsEarlyExit IS FALSE) AS IsShort,   -- Did not run for enough time (does not apply to early-exit tests)
       (test_duration > 60000.0) AS IsLong,    -- Ran for too long
       _IsCongested,
       _IsBloated

--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -111,7 +111,7 @@ UnifiedDownloadSchema AS (
       _IsRFC1918,            -- Not a real client (deprecate?)
       False AS IsPlatformAnomaly, -- FUTURE, No switch discards, etc
       (FinalSnapshot.TCPInfo.BytesAcked < 8192) AS IsSmall, -- not enough data
-      (test_duration < 9000.0 && !IsEarlyExit) AS IsShort,   -- Did not run for enough time (does not apply to early-exit tests)
+      (test_duration < 9000.0 AND !IsEarlyExit) AS IsShort,   -- Did not run for enough time (does not apply to early-exit tests)
       (test_duration > 60000.0) AS IsLong,    -- Ran for too long
       _IsCongested,
       _IsBloated


### PR DESCRIPTION
This PR removes the 9 second filter for early-exit tests since, for faster clients, these tests are likely to finish before then.

There is an early-exit test from 2023-06-07 in sandbox.

* I verified the `IsShort` value of the filter for this test before the changes:

![Screenshot 2024-02-14 4 41 51 PM](https://github.com/m-lab/etl-schema/assets/21001496/e0c81618-489d-4c30-962d-c0fa46448c40)

* And after:

![Screenshot 2024-02-14 4 44 52 PM](https://github.com/m-lab/etl-schema/assets/21001496/681b0d96-c751-4165-80cc-987a78fde5ad)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/177)
<!-- Reviewable:end -->
