### PR TITLE
Expose IsEarlyExit condition in filter struct

### DIFF
--- a/views/ndt/unified_downloads.sql
+++ b/views/ndt/unified_downloads.sql
@@ -51,11 +51,24 @@ UnifiedExtendedDownloads AS (
       AND NOT filter.IsOAM -- operations and management traffic
       AND NOT filter.IsPlatformAnomaly -- overload, bad version, etc
       AND NOT filter.IsSmall -- less than 8kB data
-      AND NOT filter.IsShort -- insufficient duration
+      AND (NOT filter.IsShort OR filter.IsEarlyExit) -- insufficient duration or early exit.
       AND NOT filter.IsLong -- excessive duraton
       -- TODO(https://github.com/m-lab/k8s-support/issues/668) deprecate? _IsRFC1918
       AND NOT filter._IsRFC1918
     ) AS IsValidBest,
+
+    -- IsValid2023 was our understanding prior to 2023-11 and addition of early exit.
+    (
+      filter.IsComplete -- Not missing any important fields
+      AND filter.IsProduction -- not a test server
+      AND NOT filter.IsError -- Server reported an error
+      AND NOT filter.IsOAM -- operations and management traffic
+      AND NOT filter.IsPlatformAnomaly -- overload, bad version, etc
+      AND NOT filter.IsSmall -- less than 8kB data
+      AND NOT filter.IsShort -- insufficient duration
+      AND NOT filter.IsLong -- excessive duraton
+      AND NOT filter._IsRFC1918
+    ) AS IsValid2023,
 
     -- IsValid2021 was our understading prior to 2022-04-01
     (

--- a/views/ndt_intermediate/extended_ndt5_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt5_downloads.sql
@@ -112,6 +112,7 @@ UnifiedDownloadSchema AS (
       (FinalSnapshot.TCPInfo.BytesAcked < 8192) AS IsSmall, -- not enough data
       (test_duration < 9000.0) AS IsShort,   -- Did not run for enough time
       (test_duration > 60000.0) AS IsLong,    -- Ran for too long
+      False AS IsEarlyExit, -- not supported for ndt5 tests.
       _IsCongested,
       _IsBloated
     ) AS filter,
@@ -172,7 +173,7 @@ UnifiedDownloadSchema AS (
       server.Network
     ) AS server,
 
-    PreComputeNDT5 AS _internal202207  -- Not stable and subject to breaking changes
+    PreComputeNDT5 AS _internal202402  -- Not stable and subject to breaking changes
 
   FROM PreComputeNDT5
 )

--- a/views/ndt_intermediate/extended_ndt5_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt5_uploads.sql
@@ -106,6 +106,7 @@ UnifiedUploadSchema AS (
       (FinalSnapshot.TCPInfo.BytesReceived < 8192) AS IsSmall, -- not enough data
       (test_duration < 9000.0) AS IsShort,   -- Did not run for enough time
       (test_duration > 60000.0) AS IsLong,    -- Ran for too long
+      False AS IsEarlyExit, -- not supported for upload tests
       False AS _IsCongested,
       False AS _IsBloated
     ) AS filter,
@@ -166,7 +167,7 @@ UnifiedUploadSchema AS (
       server.Network
     ) AS server,
 
-    PreComputeNDT5 AS _internal202207  -- Not stable and subject to breaking changes
+    PreComputeNDT5 AS _internal202402  -- Not stable and subject to breaking changes
 
   FROM PreComputeNDT5
 )

--- a/views/ndt_intermediate/extended_ndt7_downloads.sql
+++ b/views/ndt_intermediate/extended_ndt7_downloads.sql
@@ -111,8 +111,9 @@ UnifiedDownloadSchema AS (
       _IsRFC1918,            -- Not a real client (deprecate?)
       False AS IsPlatformAnomaly, -- FUTURE, No switch discards, etc
       (FinalSnapshot.TCPInfo.BytesAcked < 8192) AS IsSmall, -- not enough data
-      (test_duration < 9000.0 AND IsEarlyExit IS FALSE) AS IsShort,   -- Did not run for enough time (does not apply to early-exit tests)
+      (test_duration < 9000.0) AS IsShort,   -- Did not run for enough time
       (test_duration > 60000.0) AS IsLong,    -- Ran for too long
+      IsEarlyExit,   -- Short tests may be allowed when early-exit is true
       _IsCongested,
       _IsBloated
     ) AS filter,
@@ -173,7 +174,7 @@ UnifiedDownloadSchema AS (
       server.Network
     ) AS server,
 
-    PreComputeNDT7 AS _internal202207  -- Not stable and subject to breaking changes
+    PreComputeNDT7 AS _internal202402  -- Not stable and subject to breaking changes
 
   FROM PreComputeNDT7
 )

--- a/views/ndt_intermediate/extended_ndt7_uploads.sql
+++ b/views/ndt_intermediate/extended_ndt7_uploads.sql
@@ -105,6 +105,7 @@ UnifiedUploadSchema AS (
       (FinalSnapshot.TCPInfo.BytesReceived < 8192) AS IsSmall, -- not enough data
       (test_duration < 9000.0) AS IsShort,   -- Did not run for enough time
       (test_duration > 60000.0) AS IsLong,    -- Ran for too long
+      False AS IsEarlyExit, -- not supported for upload tests
       False AS _IsCongested,
       False AS _IsBloated
     ) AS filter,
@@ -165,7 +166,7 @@ UnifiedUploadSchema AS (
       server.Network
     ) AS server,
 
-    PreComputeNDT7 AS _internal202207  -- Not stable and subject to breaking changes
+    PreComputeNDT7 AS _internal202402  -- Not stable and subject to breaking changes
 
   FROM PreComputeNDT7
 )

--- a/views/ndt_intermediate/extended_web100_downloads.sql
+++ b/views/ndt_intermediate/extended_web100_downloads.sql
@@ -125,6 +125,7 @@ UnifiedDownloadSchema AS (
       raw.web100.snap.HCThruOctetsAcked < 8192 AS IsSmall,
       measurement_duration < 9000.0 AS IsShort,
       measurement_duration > 60000.0 AS IsLong,
+      False AS IsEarlyExit, -- not present in web100 data
       _IsCongested,
       _IsBloated
     ) AS filter,
@@ -185,7 +186,7 @@ UnifiedDownloadSchema AS (
       server.Network
     ) AS server,
 
-    PreComputeWeb100 AS _internal202207  -- Not stable and subject to breaking changes
+    PreComputeWeb100 AS _internal202402  -- Not stable and subject to breaking changes
 
   FROM PreComputeWeb100
 )

--- a/views/ndt_intermediate/extended_web100_uploads.sql
+++ b/views/ndt_intermediate/extended_web100_uploads.sql
@@ -124,6 +124,7 @@ UnifiedUploadSchema AS (
       raw.web100.snap.HCThruOctetsReceived < 8192 AS IsSmall, -- not enough data
       connection_duration < 9000.0 AS IsShort,   -- Did not run for enough time
       connection_duration > 60000.0 AS IsLong,    -- Ran for too long
+      False AS IsEarlyExit, -- not supported for upload tests
       False AS _IsCongested,
       False AS _IsBloated
     ) AS filter,
@@ -184,7 +185,7 @@ UnifiedUploadSchema AS (
       server.Network
     ) AS server,
 
-    PreComputeWeb100 AS _internal202207  -- Not stable and subject to breaking changes
+    PreComputeWeb100 AS _internal202402  -- Not stable and subject to breaking changes
 
   FROM PreComputeWeb100
 )


### PR DESCRIPTION
This change preserves the functionality added in https://github.com/m-lab/etl-schema/pull/177 and exposes the `IsEarlyExit` condition in the top level filter structure. A new condition, `IsValid2023`, represents the previous filter so we can compare the new and old conditions.

As part of that change, a new field must be added to other `filter.*` structs as well to preserve schemas across datatypes, however they are unconditionally 'False' since only ndt7 downloads currently support early exit.