### PR TITLE
Add view for ranked_spoofers1 datatype

### DIFF
--- a/views/revtr_raw/ranked_spoofers1.sql
+++ b/views/revtr_raw/ranked_spoofers1.sql
@@ -1,0 +1,3 @@
+-- This is the raw revtr view for the ranked_spoofers1 datatype.
+--
+SELECT * FROM `{{.ProjectID}}.raw_revtr.ranked_spoofers1`


### PR DESCRIPTION
Revtr has added a new datatype `ranked_spoofers1`. After testing that everything is WAI in sandbox and production ([table](https://console.cloud.google.com/bigquery?referrer=search&project=mlab-oti&ws=!1m5!1m4!4m3!1smlab-oti!2sraw_revtr!3sranked_spoofers1)), this PR adds the corresponding pass-through view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/179)
<!-- Reviewable:end -->
