### PR TITLE
Add pass-through view for autoloaded autonode ndt7 data

### DIFF
--- a/views/autojoin_autoload_v2_ndt/ndt7_union.sql
+++ b/views/autojoin_autoload_v2_ndt/ndt7_union.sql
@@ -1,0 +1,4 @@
+--
+-- This view is a pass-through for all annotated ndt7 data from autonode deployments.
+--
+SELECT * FROM `mlab-autojoin.autoload_v2_ndt.ndt7_union`

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -111,6 +111,9 @@ create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads.sql
 sed -e 's/EXCEPT.*//' -e 's/WHERE IsValidBest//' ./ndt/unified_uploads.sql > ./ndt/unified_uploads_nofilter.SQL~
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_nofilter.SQL~
 
+# Autojoin NDT7 data.
+create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/ndt7_union.sql
+
 # traceroute.
 create_view ${SRC_PROJECT} ${DST_PROJECT} traceroute ./traceroute/scamper1.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} traceroute ./traceroute/paris1_legacy.sql


### PR DESCRIPTION
This change adds a new pass-through view for the autoloaded autonode ndt7 data in the mlab-autojoin BigQuery tables so that they will be accessible from measurement-lab

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/187)
<!-- Reviewable:end -->
