### PR TITLE
Revert the change to ndt.ndt7, because it breaks unified views

### DIFF
--- a/views/ndt/ndt7.sql
+++ b/views/ndt/ndt7.sql
@@ -1,4 +1,4 @@
 --
 -- This view is a pass-through for annotated ndt7 data excluding Providence information.
 --
-SELECT * EXCEPT ( Parser )  FROM `{{.ProjectID}}.ndt.ndt7`
+SELECT * FROM `{{.ProjectID}}.ndt.ndt7`


### PR DESCRIPTION
Revert the change to ndt.ndt7, because it breaks intermediate and unified views.

Important: we need a plan to retire or update the affected views.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/189)
<!-- Reviewable:end -->
