### PR TITLE
feat(views): add scamper2 autojoin union and passthrough views

### DIFF
--- a/views/autojoin_autoload_v2_ndt/scamper2_union.sql
+++ b/views/autojoin_autoload_v2_ndt/scamper2_union.sql
@@ -1,0 +1,4 @@
+--
+-- This view is a pass-through for all scamper2 data from autonode deployments.
+--
+SELECT * FROM `mlab-autojoin.autoload_v2_ndt.scamper2_union`

--- a/views/autoload_v2_ndt/scamper2_union.sql
+++ b/views/autoload_v2_ndt/scamper2_union.sql
@@ -1,0 +1,1 @@
+-- Generated query

--- a/views/create_autojoin_dataset_views.sh
+++ b/views/create_autojoin_dataset_views.sh
@@ -44,4 +44,17 @@ if grep -q SELECT ./autoload_v2_ndt/ndt7_union.sql ; then
   create_view ${SRC_PROJECT} ${SRC_PROJECT} autoload_v2_ndt ./autoload_v2_ndt/ndt7_union.sql
 fi
 
+# scamper2 union across autojoin orgs (no join needed, reference raw directly)
+echo '-- Generated query' > ./autoload_v2_ndt/scamper2_union.sql
+for ds in $datasets ; do
+  if grep -q SELECT ./autoload_v2_ndt/scamper2_union.sql ; then
+    echo 'UNION ALL' >> ./autoload_v2_ndt/scamper2_union.sql
+  fi
+  echo 'SELECT * FROM `{{.ProjectID}}.'$ds'.scamper2_raw`' >> ./autoload_v2_ndt/scamper2_union.sql
+done
+
+if grep -q SELECT ./autoload_v2_ndt/scamper2_union.sql ; then
+  create_view ${SRC_PROJECT} ${SRC_PROJECT} autoload_v2_ndt ./autoload_v2_ndt/scamper2_union.sql
+fi
+
 echo "All views created successfully"

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -111,9 +111,10 @@ create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads.sql
 sed -e 's/EXCEPT.*//' -e 's/WHERE IsValidBest//' ./ndt/unified_uploads.sql > ./ndt/unified_uploads_nofilter.SQL~
 create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_nofilter.SQL~
 
-# union across autojoin orgs
-create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/ndt7_union.sql
-create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/scamper2_union.sql
+# Autojoin passthrough views. These reference views in mlab-autojoin which may
+# not exist yet (e.g. during initial bootstrapping), so allow failures.
+create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/ndt7_union.sql || echo "WARNING: failed to create autojoin_autoload_v2_ndt.ndt7_union (target may not exist yet)"
+create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/scamper2_union.sql || echo "WARNING: failed to create autojoin_autoload_v2_ndt.scamper2_union (target may not exist yet)"
 # union between legacy and autojoin.  These create new names
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7_legacy.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7_dynamic.sql

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -113,6 +113,7 @@ create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_nofilter.SQL
 
 # union across autojoin orgs
 create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/ndt7_union.sql
+create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/scamper2_union.sql
 # union between legacy and autojoin.  These create new names
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7_legacy.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7_dynamic.sql


### PR DESCRIPTION
## Summary
- Add `scamper2_union` view in `autoload_v2_ndt` that unions `scamper2_raw` tables across all autojoin orgs (no annotation join needed, unlike ndt7)
- Add passthrough view in `autojoin_autoload_v2_ndt` for the public `measurement-lab` project
- Allow autojoin passthrough views (both ndt7 and scamper2) to fail gracefully during bootstrapping, since they reference `mlab-autojoin` targets that may not exist yet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/190)
<!-- Reviewable:end -->
