### PR TITLE
feat(views): add public ndt.scamper2 pass-through view

### DIFF
--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -77,6 +77,7 @@ if [[ ${DST_PROJECT} = "measurement-lab" ]] ; then
     create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7.sql
     create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/tcpinfo.sql
     create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper1.sql
+    create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/scamper2.sql
     create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/web100.sql
 
     # WEHE

--- a/views/ndt/scamper2.sql
+++ b/views/ndt/scamper2.sql
@@ -1,0 +1,4 @@
+--
+-- This view is a pass-through for scamper2 traceroute data from autonode deployments.
+--
+SELECT * FROM `{{.ProjectID}}.autojoin_autoload_v2_ndt.scamper2_union`


### PR DESCRIPTION
## Summary

- Add `ndt.scamper2` pass-through view referencing `autojoin_autoload_v2_ndt.scamper2_union`
- Register the view in `create_dataset_views.sh` under the `measurement-lab` block

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/192)
<!-- Reviewable:end -->
