### PR TITLE
feat(views): add hopannotation2 autojoin union and passthrough views

### DIFF
--- a/views/autojoin_autoload_v2_ndt/hopannotation2_union.sql
+++ b/views/autojoin_autoload_v2_ndt/hopannotation2_union.sql
@@ -1,0 +1,4 @@
+--
+-- This view is a pass-through for all hopannotation2 data from autonode deployments.
+--
+SELECT * FROM `mlab-autojoin.autoload_v2_ndt.hopannotation2_union`

--- a/views/autoload_v2_ndt/hopannotation2_union.sql
+++ b/views/autoload_v2_ndt/hopannotation2_union.sql
@@ -1,0 +1,1 @@
+-- Generated query

--- a/views/create_autojoin_dataset_views.sh
+++ b/views/create_autojoin_dataset_views.sh
@@ -42,7 +42,7 @@ for ds in $datasets ; do
   if [[ -n "$tables_query" ]]; then
     tables_query+=" UNION ALL "
   fi
-  tables_query+="SELECT '${ds}' AS table_schema, table_name FROM \`${ds}\`.INFORMATION_SCHEMA.TABLES WHERE table_name IN ('ndt7_raw', 'scamper2_raw')"
+  tables_query+="SELECT '${ds}' AS table_schema, table_name FROM \`${ds}\`.INFORMATION_SCHEMA.TABLES WHERE table_name IN ('ndt7_raw', 'scamper2_raw', 'hopannotation2_raw')"
 done
 
 table_info=""
@@ -55,6 +55,8 @@ fi
 ndt7_datasets=$( echo "$table_info" | grep ndt7_raw | cut -d, -f1 )
 # Org datasets with scamper2 data (not all orgs run traceroute-caller).
 scamper2_datasets=$( echo "$table_info" | grep scamper2_raw | cut -d, -f1 )
+# Org datasets with hopannotation2 data.
+hopannotation2_datasets=$( echo "$table_info" | grep hopannotation2_raw | cut -d, -f1 )
 
 echo '-- Generated query' > ./autoload_v2_ndt/ndt7_union.sql
 for ds in $ndt7_datasets ; do
@@ -84,6 +86,19 @@ done
 
 if grep -q SELECT ./autoload_v2_ndt/scamper2_union.sql ; then
   create_view ${SRC_PROJECT} ${SRC_PROJECT} autoload_v2_ndt ./autoload_v2_ndt/scamper2_union.sql
+fi
+
+# hopannotation2 union across autojoin orgs (no join needed, reference raw directly).
+echo '-- Generated query' > ./autoload_v2_ndt/hopannotation2_union.sql
+for ds in $hopannotation2_datasets ; do
+  if grep -q SELECT ./autoload_v2_ndt/hopannotation2_union.sql ; then
+    echo 'UNION ALL' >> ./autoload_v2_ndt/hopannotation2_union.sql
+  fi
+  echo 'SELECT * FROM `{{.ProjectID}}.'$ds'.hopannotation2_raw`' >> ./autoload_v2_ndt/hopannotation2_union.sql
+done
+
+if grep -q SELECT ./autoload_v2_ndt/hopannotation2_union.sql ; then
+  create_view ${SRC_PROJECT} ${SRC_PROJECT} autoload_v2_ndt ./autoload_v2_ndt/hopannotation2_union.sql
 fi
 
 echo "All views created successfully"

--- a/views/create_dataset_views.sh
+++ b/views/create_dataset_views.sh
@@ -116,6 +116,7 @@ create_view ${DST_PROJECT} ${DST_PROJECT} ndt ./ndt/unified_uploads_nofilter.SQL
 # not exist yet (e.g. during initial bootstrapping), so allow failures.
 create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/ndt7_union.sql || echo "WARNING: failed to create autojoin_autoload_v2_ndt.ndt7_union (target may not exist yet)"
 create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/scamper2_union.sql || echo "WARNING: failed to create autojoin_autoload_v2_ndt.scamper2_union (target may not exist yet)"
+create_view ${SRC_PROJECT} ${DST_PROJECT} autojoin_autoload_v2_ndt ./autojoin_autoload_v2_ndt/hopannotation2_union.sql || echo "WARNING: failed to create autojoin_autoload_v2_ndt.hopannotation2_union (target may not exist yet)"
 # union between legacy and autojoin.  These create new names
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7_legacy.sql
 create_view ${SRC_PROJECT} ${DST_PROJECT} ndt ./ndt/ndt7_dynamic.sql


### PR DESCRIPTION
## Summary

- Add `hopannotation2_union` autojoin union view (discovers `hopannotation2_raw` tables from per-org autojoin datasets and generates a UNION ALL)
- Add `hopannotation2_union` passthrough view in `autojoin_autoload_v2_ndt` (points to `mlab-autojoin.autoload_v2_ndt.hopannotation2_union`)
- No public `ndt.hopannotation2` view for now — autojoin layer only

Follows the scamper2 pattern from #190 / #192.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/193)
<!-- Reviewable:end -->
