### PR TITLE
fix(v/n/ndt7_union.sql): comment typo

### DIFF
--- a/views/ndt/ndt7_union.sql
+++ b/views/ndt/ndt7_union.sql
@@ -1,6 +1,6 @@
 --
 -- This view is a union pass-through for annotated ndt7 data.
--- It materializes data from the legacy and dymanic fleets in one location
+-- It materializes data from the legacy and dynamic fleets in one location
 --
 SELECT * EXCEPT ( archiver ) FROM  `{{.ProjectID}}.autojoin_autoload_v2_ndt.ndt7_union`
   UNION ALL


### PR DESCRIPTION
Dynamic was wrongly spelled as "dymanic". Noticed while trying to understand union views details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/194)
<!-- Reviewable:end -->
