### PR TITLE
feat(views): annotate scamper2 with client/server

### DIFF
--- a/views/autoload_v2_ndt/scamper2_joined.template.sql
+++ b/views/autoload_v2_ndt/scamper2_joined.template.sql
@@ -1,0 +1,28 @@
+--
+-- scamper2_joined - joins the raw scamper2 and annotation2 autoloaded datasets
+-- with standard columns. This adds the server & client annotations (Geo and
+-- Network/ASN) to scamper2 traceroutes so that they can be selected by client
+-- or server, matching the annotated scamper1 tables produced by the parser
+-- pipeline. Annotations are joined by connection UUID and date.
+--
+WITH scamper2 AS (
+  SELECT
+    raw.Metadata.UUID AS id,
+    *
+  FROM `{{.ProjectID}}.autoload_v2_{{ORG}}_ndt.scamper2_raw`
+), ann2 AS (
+  SELECT raw.UUID AS id, *
+  FROM `{{.ProjectID}}.autoload_v2_{{ORG}}_ndt.annotation2_raw`
+)
+
+SELECT
+  -- Standard column order.
+  scamper2.id,
+  scamper2.date,
+  scamper2.archiver,
+  ann2.raw.server,
+  ann2.raw.client,
+  scamper2.raw
+FROM scamper2 LEFT JOIN ann2
+  ON scamper2.id = ann2.id AND scamper2.date = ann2.date
+WHERE scamper2.id IS NOT NULL

--- a/views/create_autojoin_dataset_views.sh
+++ b/views/create_autojoin_dataset_views.sh
@@ -73,13 +73,18 @@ if grep -q SELECT ./autoload_v2_ndt/ndt7_union.sql ; then
   create_view ${SRC_PROJECT} ${SRC_PROJECT} autoload_v2_ndt ./autoload_v2_ndt/ndt7_union.sql
 fi
 
-# scamper2 union across autojoin orgs (no join needed, reference raw directly).
+# scamper2 union across autojoin orgs. Each org's scamper2_raw is joined to its
+# annotation2_raw (by connection UUID) to add server & client annotations before
+# the union, mirroring the ndt7_joined pattern above.
 echo '-- Generated query' > ./autoload_v2_ndt/scamper2_union.sql
 for ds in $scamper2_datasets ; do
+  org=$( echo $ds | tr '_' ' ' | awk '{print $3}' )
+  create_org_scamper2_joined_view ${SRC_PROJECT} ${org}
   if grep -q SELECT ./autoload_v2_ndt/scamper2_union.sql ; then
-    echo 'UNION ALL' >> ./autoload_v2_ndt/scamper2_union.sql
+    # If there is already a SELECT statement in the union, append a "UNION ALL" before the next.
+    echo 'UNION ALL BY NAME' >> ./autoload_v2_ndt/scamper2_union.sql
   fi
-  echo 'SELECT * FROM `{{.ProjectID}}.'$ds'.scamper2_raw`' >> ./autoload_v2_ndt/scamper2_union.sql
+  echo 'SELECT * FROM `{{.ProjectID}}.'$ds'.scamper2_joined`' >> ./autoload_v2_ndt/scamper2_union.sql
 done
 
 if grep -q SELECT ./autoload_v2_ndt/scamper2_union.sql ; then

--- a/views/create_view_lib.sh
+++ b/views/create_view_lib.sh
@@ -59,3 +59,11 @@ function create_org_joined_view() {
   sed -e 's/{{ORG}}/'${org}'/g' autoload_v2_ndt/ndt7_joined.template.sql > autoload_v2_${org}_ndt/ndt7_joined.sql
   create_view ${project} ${project} autoload_v2_${org}_ndt ./autoload_v2_${org}_ndt/ndt7_joined.sql
 }
+
+function create_org_scamper2_joined_view() {
+  local project=$1
+  local org=$2
+  mkdir -p autoload_v2_${org}_ndt
+  sed -e 's/{{ORG}}/'${org}'/g' autoload_v2_ndt/scamper2_joined.template.sql > autoload_v2_${org}_ndt/scamper2_joined.sql
+  create_view ${project} ${project} autoload_v2_${org}_ndt ./autoload_v2_${org}_ndt/scamper2_joined.sql
+}


### PR DESCRIPTION
## Summary

Adds `client`/`server` annotations to autoloaded scamper2 traceroutes.

Autoloaded scamper2 traceroutes had only standard columns + `raw`, with no `client`/`server`, so they couldn't be selected by client/server geo or ASN. This adds a per-org view (`views/autoload_v2_ndt/scamper2_joined.template.sql`) that `LEFT JOIN`s `scamper2_raw` to `annotation2_raw` on UUID + date, mirroring `ndt7_joined`. `create_autojoin_dataset_views.sh` now unions the joined views, so `ndt.scamper2` gains `server`/`client`. Verified in sandbox: 2,844 / 2,844 recent traceroutes annotated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-schema/196)
<!-- Reviewable:end -->
